### PR TITLE
docs: launch-focused README + architecture diagram; kill em-dashes

### DIFF
--- a/.github/workflows/gpu-smoke.yml
+++ b/.github/workflows/gpu-smoke.yml
@@ -1,7 +1,7 @@
 name: gpu-smoke
 
 # Optional smoke test that exercises the AWS MCP exec tool against an
-# EXISTING GPU instance. This workflow MUST NOT provision capacity — it
+# EXISTING GPU instance. This workflow MUST NOT provision capacity - it
 # only runs `nvidia-smi` via SSM SendCommand on a pre-existing instance
 # whose ID is provided as a repo secret.
 #
@@ -29,7 +29,7 @@ jobs:
         shell: bash
         run: |
           if [[ -z "${{ secrets.FORMICA_GPU_INSTANCE_ID }}" ]]; then
-            echo "No FORMICA_GPU_INSTANCE_ID secret — skipping (expected in forks)."
+            echo "No FORMICA_GPU_INSTANCE_ID secret - skipping (expected in forks)."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -1,81 +1,153 @@
 # Formica
 
-**Formica** is a stigmergic, ant-colony-inspired multi-agent system for autonomous problem solving.
-It is the spiritual successor to [`abacus2000/rome`](https://github.com/abacus2000/rome): same stack
-(Kubernetes, Strands Agents, Neo4j, AWS), but the coordination model is replaced with stigmergy — agents
-coordinate by reading and writing a shared artifact (a typed task graph with pheromone-weighted edges),
-not by messaging each other.
+**Formica** is a stigmergic, ant-colony-inspired multi-agent system for
+autonomous problem solving. Agents do not message each other. They
+coordinate by reading and writing a shared artifact: a typed task
+graph with pheromone-weighted edges, stored in Neo4j.
 
 > "Intelligence is a property of the colony, not the ant."
 
-## What's different from Rome
+## What is Formica
 
-| Rome                                   | Formica                                               |
-| -------------------------------------- | ----------------------------------------------------- |
-| Princeps decides deployment (hierarchy) | No dispatcher. Workers follow pheromone gradients.    |
-| Legion / Civitas (direct / deliberative) | Single worker pool with role reallocation (Gordon).  |
-| Censor as metrics sink                  | Validator caste emits `validated` pheromone.          |
-| Inter-service HTTP messaging            | All coordination via the **Forum** (Neo4j blackboard).|
-| Kaizen agents propose changes          | Phase cycling + `anternet`-style spawn feedback.      |
-| Capacity provisioning                  | **Never provisions**. Capacity-aware, passive growth. |
+- **Forum (blackboard).** Neo4j graph of sub-problems, partial
+  solutions, evidence, and validations. This is the only coordination
+  channel. No inter-agent HTTP.
+- **Pheromones.** Per-edge scalars across six channels (`promising`,
+  `validated`, `risky`, `needs-expert`, `dead-end`, `alarm`), each
+  with its own evaporation half-life. Agents follow gradients.
+- **Castes.** Scouts decompose problems. Foragers produce evidence.
+  Validators judge it. A GC caste prunes stale branches. Inquilines
+  are narrow specialists (citation checking, numeric sanity).
+- **Role reallocation (Gordon's rule).** Agents re-specialize based on
+  local encounter rates, so the colony rebalances without a central
+  scheduler.
+- **Phase cycling.** The colony alternates exploration and
+  consolidation phases based on pheromone entropy.
+- **Alarm propagation.** Fast, short-lived pheromone that preempts
+  work on failure or hallucination.
+- **Capacity awareness, never provisioning.** The spawn controller
+  observes cluster headroom each tick and schedules within it. It
+  never requests new compute. Nodes added at runtime are absorbed
+  passively on the next tick.
 
-See [`docs/port-notes.md`](docs/port-notes.md) for the full mapping.
+### Architecture
 
-## Core ideas
+```mermaid
+flowchart LR
+    CLI["formica solve<br/>(thin client)"]
 
-- **Forum (blackboard)** — Neo4j graph of sub-problems, partial solutions, evidence, validations.
-- **Pheromones** — per-edge scalars across six channels (`promising`, `validated`, `risky`,
-  `needs-expert`, `dead-end`, `alarm`), each with its own evaporation half-life.
-- **Castes** — Scouts, Foragers, Validators (Censors), GC (Lustrum), and narrow Inquilines.
-- **Role reallocation (Gordon's rule)** — agents re-specialize based on local encounter rates.
-- **Phase cycling** — colony alternates exploration and consolidation based on pheromone entropy.
-- **Necrophoresis** — a GC caste prunes stale / decayed branches.
-- **Alarm propagation** — fast, short-lived pheromone that preempts work on failure / hallucination.
-- **Capacity awareness** — spawn controller observes cluster headroom; never requests new compute;
-  passively absorbs nodes added at runtime.
+    subgraph cluster["Kubernetes cluster (k3d or EKS)"]
+        direction TB
 
-## Quick start
+        CTRL["Controller<br/>capacity-aware<br/>spawn / retire"]
+
+        subgraph castes["Agent castes (Jobs)"]
+            direction TB
+            SC["Scout"]
+            FO["Forager"]
+            VA["Validator"]
+            GC["GC"]
+            INQ["Inquilines"]
+        end
+
+        NEO[("Forum<br/>Neo4j: task graph<br/>+ pheromones")]
+        VLLM["vLLM<br/>OpenAI-compatible"]
+    end
+
+    subgraph aws["AWS (observability)"]
+        direction TB
+        CW[("CloudWatch<br/>errors + drivers")]
+        S3[("S3 + Athena<br/>OTEL Parquet")]
+    end
+
+    CLI -->|write Objective / poll| NEO
+
+    CTRL -->|spawns / retires<br/>within headroom| castes
+
+    castes <-->|read / write| NEO
+    castes -->|LLM calls| VLLM
+
+    castes -.->|OTEL| S3
+    castes -.->|logs| CW
+```
+
+Agents never talk to each other. Every arrow into or out of the
+colony goes through the Forum (Neo4j) or the model server. The
+controller's only job is to keep the right mix of pods running
+within whatever cluster headroom happens to exist.
+
+## Launch
 
 Formica is Kubernetes-native end-to-end. The same manifests work on a
 single box (via [k3d](https://k3d.io/)) and on a real EKS cluster.
+There is no separate Docker Compose stack and no in-process mode.
 
-### Single GPU box (k3d)
+### Prerequisites
 
-Canonical environment: a `g4dn.xlarge` launched from the prebaked
-open-weight AMI shared with `rome` (`ami-079c82d610e02e480`: AL2023 +
-NVIDIA drivers + CUDA + Docker + Mistral-7B-Instruct-v0.2-AWQ weights
-at `/opt/models/mistral-awq`).
+- Docker, `kubectl`, `kustomize`, and `k3d` on your PATH.
+- For local GPU inference: an NVIDIA GPU with drivers and
+  `nvidia-container-toolkit` installed, plus Mistral-7B-AWQ weights at
+  `/opt/models/mistral-awq` on the host. (Skip this if you override to
+  Bedrock or OpenAI via `FORMICA_MODEL_PROVIDER`.)
+- For AWS observability: valid AWS credentials in the shell that runs
+  `kubectl apply` (IRSA handles pod-level auth once deployed).
+
+### 1. Create a single-node GPU cluster
 
 ```bash
-ssh ec2-user@<instance>
-git clone https://github.com/abacus2000/formica.git && cd formica
-
 k3d cluster create formica \
   --gpus all \
   --volume "/opt/models:/opt/models@all" \
   --port "8080:8080@loadbalancer" \
   --port "7474:7474@loadbalancer" \
   --port "7687:7687@loadbalancer"
+
 kubectl apply -f \
   https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.15.0/deployments/static/nvidia-device-plugin.yml
+```
+
+### 2. Deploy Formica
+
+```bash
+git clone https://github.com/abacus2000/formica.git && cd formica
 kubectl apply -k deploy/k8s/overlays/dev
 kubectl -n formica rollout status deploy/vllm --timeout=15m
+```
 
+The `vllm` rollout is the slow one (60-120s on the prebaked GPU AMI,
+up to 15 minutes if weights are downloaded from HuggingFace). The
+controller, Neo4j, and OTEL collector come up in seconds.
+
+### 3. Submit an objective
+
+```bash
 pip install -e ".[dev]"
+
+# Port-forward Neo4j and vLLM so the CLI can reach them from outside
+# the cluster.
 kubectl -n formica port-forward svc/neo4j 7687:7687 &
 kubectl -n formica port-forward svc/vllm  8080:8080 &
+
 export FORMICA_NEO4J_URI=bolt://localhost:7687
 export FORMICA_MODEL_BASE_URL=http://localhost:8080/v1
+
 formica solve "Prove sqrt(2) is irrational" --budget 1 --timeout 600
 ```
 
-Full walk-through: [`docs/single-box.md`](docs/single-box.md).
+Validated Evidence streams to stdout as Validator pods emit it.
+
+### Watch the colony
+
+```bash
+kubectl -n formica logs -f deploy/formica-controller   # spawn/retire decisions
+watch kubectl -n formica get pods                       # live caste mix
+open http://localhost:7474                              # Neo4j browser
+```
 
 ### Multi-node (EKS)
 
 Same manifests, with a prod overlay that swaps the vLLM `hostPath` for
-a real PVC and sets IRSA annotations on the OTEL / Fluent Bit service
-accounts.
+a PVC and sets IRSA annotations:
 
 ```bash
 kubectl apply -k deploy/k8s/overlays/prod
@@ -83,24 +155,16 @@ formica solve "Prove sqrt(2) is irrational with three independent methods" \
   --budget 2 --timeout 600 --env prod --region us-east-1
 ```
 
+Full walkthrough: [`docs/single-box.md`](docs/single-box.md).
+
 ## Observability
 
-- **CloudWatch** (errors + driver logs): `/formica/{env}/{region}/errors`, `/formica/{env}/{region}/drivers`
-- **S3 + Athena** (OTEL traces/metrics/logs as Parquet): `formica-otel-{env}-{region}`
+- **CloudWatch** (errors + driver logs):
+  `/formica/{env}/{region}/errors`, `/formica/{env}/{region}/drivers`
+- **S3 + Athena** (OTEL traces / metrics / logs as Parquet):
+  `formica-otel-{env}-{region}`
 
 See [`docs/observability.md`](docs/observability.md).
-
-## Roman aliases
-
-Formica's canonical vocabulary is ant-colony. Roman terms are available as readability aliases:
-
-| Formica (canonical) | Rome alias |
-| ------------------- | ---------- |
-| agent pod           | Castra     |
-| trail               | Via        |
-| validator           | Censor     |
-| GC pass             | Lustrum    |
-| blackboard          | Forum      |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,29 @@ Full walkthrough: [`docs/single-box.md`](docs/single-box.md).
 
 See [`docs/observability.md`](docs/observability.md).
 
+## Credits and inspiration
+
+Formica's design draws on peer-reviewed work in multi-agent systems,
+distributed algorithms, and ant colony biology. The annotated reading
+list - with notes on which paper shaped which component - lives in
+[`docs/references.md`](docs/references.md).
+
+A few load-bearing sources:
+
+- Rodriguez 2026, *Pressure Fields and Temporal Decay* - the core
+  coordination model behind Formica's pheromone grid and decay.
+- Garg, Shiragur, Gordon, Charikar 2023, *Distributed algorithms from
+  arboreal ants* - shortest-path reinforcement on the evidence graph.
+- Chandrasekhar, Gordon, Navlakha 2018, *Trail repair* - how the
+  colony recovers after a pod is retired or a Validator fails.
+- Prabhakar, Dektar, Gordon 2012, *Anternet* - outgoing-rate control
+  tuned by return signals; Formica's Controller spawns new Workers by
+  the same rule.
+- Gordon & Mehdiabadi 1999, *Encounter rate and task allocation* -
+  the local-interaction basis for Gordon's rule in the Controller.
+- Friedman et al 2021, *Active Inferants* - active-inference framing
+  for individual agents inside a stigmergic colony.
+
 ## License
 
 [MIT](LICENSE)

--- a/deploy/helm/formica/Chart.yaml
+++ b/deploy/helm/formica/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: formica
-description: Formica — stigmergic, ant-colony-inspired multi-agent system
+description: Formica - stigmergic, ant-colony-inspired multi-agent system
 type: application
 version: 0.1.0
 appVersion: "0.1.0"

--- a/deploy/helm/formica/templates/neo4j.yaml
+++ b/deploy/helm/formica/templates/neo4j.yaml
@@ -1,6 +1,6 @@
 {{- /*
 Neo4j StatefulSet + headless Service for the blackboard (Forum).
-Single replica by design — the colony's blackboard is authoritative
+Single replica by design - the colony's blackboard is authoritative
 state, not a horizontally-scaled cache.
 */ -}}
 apiVersion: v1

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,11 +39,11 @@ flowchart TB
 
 Neo4j graph. Node labels:
 
-- `:Objective` — the top-level problem. One per `formica solve` invocation.
-- `:SubProblem` — a decomposition; created by Scouts.
-- `:Evidence` — a partial solution, quote, computation, or claim; written by Foragers.
-- `:Validation` — a verdict on an Evidence node; written by Validators.
-- `:Alarm` — a transient event (hallucination, tool failure, budget overrun).
+- `:Objective` - the top-level problem. One per `formica solve` invocation.
+- `:SubProblem` - a decomposition; created by Scouts.
+- `:Evidence` - a partial solution, quote, computation, or claim; written by Foragers.
+- `:Validation` - a verdict on an Evidence node; written by Validators.
+- `:Alarm` - a transient event (hallucination, tool failure, budget overrun).
 
 Edge types:
 
@@ -86,7 +86,7 @@ Agents are **stateless between ticks**. Everything durable goes to the Forum.
 | Scout           | Creates new `SubProblem` nodes from unclaimed objectives; seeds `promising` | new nodes + edges |
 | Forager         | Picks a `SubProblem` by gradient; produces `Evidence` | `Evidence`, `SUPPORTS` with `promising`    |
 | Validator       | Verifies `Evidence` (unit test, consistency, citation) | `Validation` with `validated` or `dead-end` |
-| Inquiline       | Narrow specialist — runs only when `needs-expert` or a specific pattern matches | depends                                    |
+| Inquiline       | Narrow specialist - runs only when `needs-expert` or a specific pattern matches | depends                                    |
 | GC (Lustrum)    | Prunes nodes whose all-channel pheromone sum is below threshold for N cycles | deletes                                  |
 
 ## Phase cycling

--- a/docs/capacity.md
+++ b/docs/capacity.md
@@ -24,7 +24,7 @@ Each pool has:
 
 - `min_replicas`, `max_replicas` (hard caps from Helm values)
 - `priority` (used to break ties under pressure)
-- `headroom_quota` — fraction of remaining cluster headroom this pool may use
+- `headroom_quota` - fraction of remaining cluster headroom this pool may use
 
 On each tick:
 
@@ -69,4 +69,4 @@ config change.
 - `ec2:RunInstances` is not in any Formica IAM policy.
 - CI runs `grep -RIn "run_instances\|eks:UpdateNodegroup" formica/` and fails if any hits.
 - The controller's unit tests include a case where the Kubernetes API is mocked to
-  report zero headroom — the expected behavior is throttle + alarm, not any outbound call.
+  report zero headroom - the expected behavior is throttle + alarm, not any outbound call.

--- a/docs/decisions/0001-stigmergy-over-hierarchy.md
+++ b/docs/decisions/0001-stigmergy-over-hierarchy.md
@@ -19,7 +19,7 @@ an action by pheromone gradient, and write pheromone back. No inter-agent chat c
 
 - **+** No single point of coordination. The colony throughput scales with worker count and
   Neo4j write throughput, not with a manager's LLM latency.
-- **+** Emergent specialization via Gordon's rule — no need to pre-classify work as
+- **+** Emergent specialization via Gordon's rule - no need to pre-classify work as
   "legion" or "civitas".
 - **+** Failure is local. A dead worker leaves stale pheromone that evaporates; no
   orphan-reconciliation logic needed.

--- a/docs/decisions/0003-fluent-bit-cloudwatch.md
+++ b/docs/decisions/0003-fluent-bit-cloudwatch.md
@@ -6,7 +6,7 @@
 ## Context
 
 OTEL carries structured signals. Operators still need low-latency, grep-able access
-to raw pod stdout/stderr — especially for driver-layer noise (Neo4j client, Strands
+to raw pod stdout/stderr - especially for driver-layer noise (Neo4j client, Strands
 runtime, Kubernetes client, AWS SDK, CUDA driver messages from GPU pods).
 
 ## Decision
@@ -14,8 +14,8 @@ runtime, Kubernetes client, AWS SDK, CUDA driver messages from GPU pods).
 Deploy `aws-for-fluent-bit` as a DaemonSet. Configure a routing filter that classifies
 records by severity and component and writes to one of two log groups per env+region:
 
-- `/formica/{env}/{region}/errors` — `ERROR` / `CRITICAL` from any component.
-- `/formica/{env}/{region}/drivers` — all records from driver-layer components.
+- `/formica/{env}/{region}/errors` - `ERROR` / `CRITICAL` from any component.
+- `/formica/{env}/{region}/drivers` - all records from driver-layer components.
 
 Log stream pattern: `{component}/{pod-name}/{start-timestamp}`. Retention is 30 days
 (dev) / 180 days (prod). A CloudWatch metric-filter alarm on error rate publishes to
@@ -25,4 +25,4 @@ an SNS topic `formica-{env}-{region}-alerts`.
 
 - **+** Two narrow, predictable log groups per environment instead of one firehose.
 - **+** SNS alerts are easy to subscribe to (email/Slack).
-- **−** A small amount of duplication with OTEL logs (intentional — different consumers).
+- **−** A small amount of duplication with OTEL logs (intentional - different consumers).

--- a/docs/decisions/0004-terraform-env-region.md
+++ b/docs/decisions/0004-terraform-env-region.md
@@ -20,7 +20,7 @@ and IAM scoping keyed to `{env}` and `{region}`:
 - IAM roles: `formica-agent-{env}-{region}`, `formica-controller-{env}-{region}`,
   `formica-otel-{env}-{region}`, `formica-fluentbit-{env}-{region}`
 
-IAM policies use resource ARNs scoped to the env+region naming pattern only — no `*` resource wildcards.
+IAM policies use resource ARNs scoped to the env+region naming pattern only - no `*` resource wildcards.
 
 ## Consequences
 

--- a/docs/decisions/0006-no-capacity-provisioning.md
+++ b/docs/decisions/0006-no-capacity-provisioning.md
@@ -1,4 +1,4 @@
-# ADR-0006: No capacity provisioning — ever
+# ADR-0006: No capacity provisioning - ever
 
 **Status**: Accepted (constraint)
 **Date**: 2026-04-19
@@ -19,13 +19,13 @@ Run-Instances, no Karpenter triggers, no GPU-capacity MCP. The spawn/retire cont
 2. Respects per-pool budgets derived from headroom.
 3. If headroom is insufficient: throttles spawn rate, promotes lower-priority agents
    to retirement, or emits `alarm` pheromone. Never escalates outward.
-4. Detects newly added nodes (human action or external autoscaler) passively —
+4. Detects newly added nodes (human action or external autoscaler) passively -
    on the next tick, headroom increases and spawns resume with no config change.
 
 ## Consequences
 
 - **+** Predictable cost ceiling per cluster.
-- **+** Playing nicely with existing autoscaler strategies (Karpenter, CA) — the
+- **+** Playing nicely with existing autoscaler strategies (Karpenter, CA) - the
   controller is agnostic to how nodes arrive.
 - **−** Users must size the cluster for peak load or accept back-pressure.
 

--- a/docs/decisions/0007-open-weight-default.md
+++ b/docs/decisions/0007-open-weight-default.md
@@ -29,7 +29,7 @@ Formica defaults to the same open-weight model, served the same way:
   `FORMICA_MODEL_BASE_URL=http://localhost:8080/v1`.
 - `FormicaConfig.model_id` defaults to `TheBloke/Mistral-7B-Instruct-v0.2-AWQ`.
 - `FormicaConfig.model_provider` defaults to `openai` (the provider
-  protocol, not the vendor — vLLM speaks it natively).
+  protocol, not the vendor - vLLM speaks it natively).
 - vLLM ships as an in-cluster `Deployment` + `Service`
   (`deploy/k8s/base/vllm.yaml`) with weights bind-mounted via
   `hostPath` on single-box clusters; swap for a PVC in EKS overlays.

--- a/docs/decisions/0008-k8s-only-single-box-first-class.md
+++ b/docs/decisions/0008-k8s-only-single-box-first-class.md
@@ -19,7 +19,7 @@ These two paths executed *different code*. Path 1 skipped the
 controller entirely and drove Scouts/Foragers/Validators/GC inline from
 the CLI process. Path 2 was the real system. This created two
 maintenance burdens and, more importantly, meant single-box users were
-not exercising the code that runs in production — defeating the point
+not exercising the code that runs in production - defeating the point
 of single-box dev.
 
 The controller's use of Kubernetes (Jobs for agents, CoreV1 for node
@@ -28,7 +28,7 @@ single-node k3s cluster (via k3d) runs all of it unchanged: Jobs land
 on the one available node, `compute_headroom` reads that node's free
 CPU/mem, and `budget()` scales spawns against it. The only thing
 single-box mode actually needs that multi-node doesn't is a local vLLM
-with GPU access — and that's a `hostPath`-mounted Deployment, not a
+with GPU access - and that's a `hostPath`-mounted Deployment, not a
 reason to have a second runtime.
 
 ## Decision
@@ -55,7 +55,7 @@ reason to have a second runtime.
   collector by default).
 - **Keep Compose, delete `--local`.** Rejected: Compose without
   `--local` is just "two infra containers with no colony running,"
-  which is a footgun — users would `docker compose up` and see
+  which is a footgun - users would `docker compose up` and see
   nothing happen.
 - **Delete K8s, make Compose canonical.** Rejected: throws away the
   capacity-aware controller, per-agent resource isolation, RBAC, IRSA,

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -11,7 +11,7 @@ use `env=dev`, `region=us-east-1`.
 
 ---
 
-## Run 1 — Math: "Prove sqrt(2) is irrational"
+## Run 1 - Math: "Prove sqrt(2) is irrational"
 
 ### CLI
 
@@ -55,7 +55,7 @@ formica solve "Prove sqrt(2) is irrational. Present a classical proof." \
 ▸ tick 5  stable cycles: 3/3  ← converged
 ✓ validated answer (subtree o-3f1a.../contradiction approach):
     Assume sqrt(2) = p/q in lowest terms. Then 2q^2 = p^2, so p is even,
-    p = 2k, so q^2 = 2k^2, so q is even — contradicting lowest terms. ∎
+    p = 2k, so q^2 = 2k^2, so q is even - contradicting lowest terms. ∎
 spend: $0.41 / $2.00   wallclock: 84s / 600s
 ```
 
@@ -66,7 +66,7 @@ spend: $0.41 / $2.00   wallclock: 84s / 600s
 - **Driver logs (neo4j, strands, kubernetes, botocore, …):**
   [/formica/dev/us-east-1/drivers](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Fformica$252Fdev$252Fus-east-1$252Fdrivers)
 
-### Athena query — pheromone history on the winning edge
+### Athena query - pheromone history on the winning edge
 
 ```sql
 SELECT ts, channel, value
@@ -88,7 +88,7 @@ Mock result:
 
 ---
 
-## Run 2 — Research: "Compare CNN vs ViT on ImageNet-1k (top-1)"
+## Run 2 - Research: "Compare CNN vs ViT on ImageNet-1k (top-1)"
 
 ### CLI
 
@@ -116,8 +116,8 @@ formica solve "Compare CNN vs ViT top-1 accuracy on ImageNet-1k with sources." \
 
 ```
 ✓ validated answer:
-  CNN (ConvNeXt-XL, IN-21k pretrain): 87.8% top-1 — [paper](https://…)
-  ViT  (ViT-H/14, JFT-300M pretrain): 88.55% top-1 — [paper](https://…)
+  CNN (ConvNeXt-XL, IN-21k pretrain): 87.8% top-1 - [paper](https://…)
+  ViT  (ViT-H/14, JFT-300M pretrain): 88.55% top-1 - [paper](https://…)
   Gap: ≈0.75 pp in favour of ViT at equivalent pretrain scale.
 spend: $1.22 / $3.00  wallclock: 312s / 900s
 ```
@@ -160,4 +160,4 @@ alarm, no new pods are created, and no AWS provisioning API is called
 (verified by the `ci.yml → No provisioning APIs` grep step and by CloudTrail).
 
 When you uncordon a node, the Controller picks up the new capacity on
-its next 10s tick — no restart, no config change.
+its next 10s tick - no restart, no config change.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,12 +2,12 @@
 
 Formica logs are split into two sinks by purpose and environment:
 
-## 1. CloudWatch — error and driver logs
+## 1. CloudWatch - error and driver logs
 
 | Log group                               | What lands here                                                                    |
 | --------------------------------------- | ---------------------------------------------------------------------------------- |
 | `/formica/{env}/{region}/errors`        | `ERROR`/`CRITICAL` from any component, panics, tool failures, validator rejections, alarm pheromone events |
-| `/formica/{env}/{region}/drivers`       | Driver-layer logs — Neo4j client, Strands runtime, Kubernetes client, AWS SDK, MCP clients, CUDA / GPU driver messages from GPU pods |
+| `/formica/{env}/{region}/drivers`       | Driver-layer logs - Neo4j client, Strands runtime, Kubernetes client, AWS SDK, MCP clients, CUDA / GPU driver messages from GPU pods |
 
 Log stream pattern: `{component}/{pod-name}/{start-timestamp}`.
 
@@ -23,7 +23,7 @@ Retention: **30 days (dev), 180 days (prod)**. Configurable via Helm values.
 An alarm on the 5-minute error rate publishes to SNS topic
 `formica-{env}-{region}-alerts`.
 
-## 2. S3 — OpenTelemetry Parquet
+## 2. S3 - OpenTelemetry Parquet
 
 Every agent tick, pheromone write, validator verdict, alarm event, and spawn/retire
 decision emits a structured OTEL span.
@@ -35,8 +35,8 @@ decision emits a structured OTEL span.
 - **Key layout**:
   `year=YYYY/month=MM/day=DD/hour=HH/{signal}/{component}/{trace_id}.parquet`
   where `signal ∈ {traces, metrics, logs}`.
-- **Glue table**: defined in `deploy/terraform/glue/` — one external table per signal.
-- **Athena**: pre-built queries in `athena/` — `recent_errors.sql`,
+- **Glue table**: defined in `deploy/terraform/glue/` - one external table per signal.
+- **Athena**: pre-built queries in `athena/` - `recent_errors.sql`,
   `pheromone_history.sql`, `agent_lifecycle.sql`, `validation_outcomes.sql`.
 
 ## Finding the logs for a run
@@ -45,12 +45,12 @@ Every `formica solve` invocation creates a `run_id` (UUID) and an OTEL root span
 `trace_id` is stamped on every child span. To investigate a run:
 
 ```bash
-# CloudWatch — scope to a run
+# CloudWatch - scope to a run
 aws logs filter-log-events \
   --log-group-name /formica/dev/us-east-1/errors \
   --filter-pattern '{ $.run_id = "abcd1234" }'
 
-# Athena — scope to a trace_id
+# Athena - scope to a trace_id
 SELECT * FROM formica_otel_dev_us_east_1.traces
 WHERE trace_id = 'abcd1234...' ORDER BY start_time_unix_nano;
 ```

--- a/docs/port-notes.md
+++ b/docs/port-notes.md
@@ -38,7 +38,7 @@ samples its next action by pheromone gradient, and writes pheromone back. Coordi
 | DuckDuckGo `web_search` / `web_fetch` | Same tools, carried over                          | Keep             | Moved to `formica/tools/web.py`. |
 | ATT&CK MCP server                 | *(pack-able, not included)*                           | Drop (for v0.1)  | Can be added as a pack later; not required for acceptance. |
 | AWS MCP tool for exec on GPU box  | `formica/tools/aws_exec.py`                           | Keep             | Executes commands on **existing** GPU instances only. No provisioning paths. |
-| *(new)*                           | **GC (Lustrum) caste**                                | Add              | Necrophoresis — prunes nodes whose all-channel pheromone is below threshold. |
+| *(new)*                           | **GC (Lustrum) caste**                                | Add              | Necrophoresis - prunes nodes whose all-channel pheromone is below threshold. |
 | *(new)*                           | **Alarm pheromone**                                   | Add              | Fast decay, wide radius; preempts work on hallucination/tool failure/budget overrun. |
 
 ## Stack decisions
@@ -46,20 +46,20 @@ samples its next action by pheromone gradient, and writes pheromone back. Coordi
 ### Kept
 - **Kubernetes** (EKS) as runtime. Minikube supported for local dev.
 - **Strands Agents** as the LLM agent primitive.
-- **Neo4j** as the graph store — promoted from an ATT&CK-pack optional to the core Forum.
+- **Neo4j** as the graph store - promoted from an ATT&CK-pack optional to the core Forum.
 - **AWS MCP tool** for executing commands on pre-existing GPU instances.
 - **Helm** (and Kustomize overlays) for deployment.
 
 ### Added
-- **OpenTelemetry Collector** (OTLP in, S3 Parquet out) — see ADR-0002.
-- **aws-for-fluent-bit** DaemonSet — see ADR-0003.
-- **Terraform** for cloud resources (S3, Glue, CloudWatch log groups, SNS, IAM) scoped by `{env}`/`{region}` — see ADR-0004.
-- **Click-based CLI** `formica solve ...` — see ADR-0005.
+- **OpenTelemetry Collector** (OTLP in, S3 Parquet out) - see ADR-0002.
+- **aws-for-fluent-bit** DaemonSet - see ADR-0003.
+- **Terraform** for cloud resources (S3, Glue, CloudWatch log groups, SNS, IAM) scoped by `{env}`/`{region}` - see ADR-0004.
+- **Click-based CLI** `formica solve ...` - see ADR-0005.
 
 ### Dropped
-- **Princeps service / Senate / Augur / Optio / Tribune** — replaced by emergent coordination (ADR-0001).
-- **Censor HTTP service + PVC** — replaced by OTEL + S3 (ADR-0002).
-- **Any GPU-capacity provisioning MCP** — explicitly excluded by constraint. Capacity is
+- **Princeps service / Senate / Augur / Optio / Tribune** - replaced by emergent coordination (ADR-0001).
+- **Censor HTTP service + PVC** - replaced by OTEL + S3 (ADR-0002).
+- **Any GPU-capacity provisioning MCP** - explicitly excluded by constraint. Capacity is
   observed, never requested (ADR-0006).
 
 ## Read order for maintainers

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,0 +1,400 @@
+# References
+
+This is the academic reading list behind Formica's design. Each entry
+says what the paper contributes, what else in the ecosystem draws on
+the same idea, and which specific Formica components or sections of
+this codebase the paper inspired.
+
+The list is intentionally narrow: peer-reviewed journal articles,
+arXiv preprints, and primary-source institutional reporting. Blog
+posts, forum threads, and encyclopedia entries are useful for
+intuition but are not cited as sources of record.
+
+## Reading order
+
+Shortest path through the material:
+
+1. Rodriguez 2026 (Pressure Fields)
+2. Garg, Shiragur, Gordon, Charikar 2023 (arboreal ants shortest path)
+3. Chandrasekhar, Gordon, Navlakha 2018 (arboreal ants trail repair)
+4. Prabhakar, Dektar, Gordon 2012 (Anternet, via the Stanford
+   Engineering report)
+5. Gordon & Mehdiabadi 1999 (encounter rate task allocation)
+6. Friedman, Tschantz, Ramstead, Friston, Constant 2021 (Active
+   Inferants)
+
+That sequence walks from system architecture to distributed control
+to the colony-level biology that makes the metaphor hold up.
+
+## Architecture
+
+### Emergent Coordination in Multi-Agent Systems via Pressure Fields and Temporal Decay
+
+- Rodriguez, R. (2026). arXiv:2601.08129.
+  [link](https://arxiv.org/abs/2601.08129)
+- **What it contributes.** A formal argument and empirical benchmark
+  for coordinating LLM agents through gradients on a shared artifact
+  rather than through explicit orchestration. Proves convergence
+  under mild conditions and shows 48.5% solve rate on meeting room
+  scheduling vs 12.6% for conversation-based, 1.5% for hierarchical,
+  0.4% for sequential baselines across 1,350 trials. Ablation
+  demonstrates temporal decay is essential: disabling it drops solve
+  rate by 10 percentage points.
+- **Seen elsewhere.** The "shared artifact + decay" formulation is
+  the LLM-era restatement of the 1980s blackboard architecture
+  (Hayes-Roth 1985, below) with time-varying weights instead of a
+  static scheduler. Pressure-field thinking also appears in robot
+  swarm coordination and in the ant-colony optimization family
+  descended from Dorigo's 1992 thesis.
+- **Inspires in Formica.**
+  - The six pheromone channels with per-channel evaporation
+    half-lives (`formica/pheromones/constants.py`) are a direct
+    implementation of "pressure gradients with temporal decay."
+  - The controller's decision to never provision new compute
+    (ADR-0006) follows the paper's observation that coordination
+    overhead, not raw capacity, is the limiting factor.
+  - The `validated` pheromone as first-class signal (vs logs) is the
+    "measurable quality signal" from the paper's Section on quality
+    gradients.
+
+### Self-Organizing Multi-Agent Systems for Continuous Software Development
+
+- Lyu, W., Xiao, Y., Zhang, Y., Sun, Y. (2026). arXiv:2603.25928.
+  [link](https://arxiv.org/abs/2603.25928)
+- **What it contributes.** Three-phase state machine (Strategy to
+  Execution to Verification), self-organizing teams where manager
+  agents hire / assign / fire workers based on project state, and
+  asynchronous human oversight for milestone-driven work. Tests on
+  real software projects over multiple days.
+- **Seen elsewhere.** The hire/fire-by-need pattern echoes dynamic
+  thread-pool sizing in server runtimes and the autoscaler pattern
+  in Kubernetes. The explicit Verification phase is the modern form
+  of the classic test-in-loop idea from extreme programming.
+- **Inspires in Formica.**
+  - Phase cycling in `formica/coordinator/phases.py` (exploration
+    vs consolidation) borrows the idea of globally-visible phase
+    state that gates which agents act when, though Formica swaps
+    Strategy/Execution/Verification for exploration/consolidation
+    driven by pheromone entropy.
+  - The Validator caste mirrors their Verification phase: a
+    dedicated caste that only judges, never produces.
+  - The capacity controller's spawn/retire loop is the "hire and
+    fire" primitive, constrained by ADR-0006 to never ask for more
+    compute than the cluster already has.
+
+### BB1: An architecture for blackboard systems that control, explain, and learn about their own behavior
+
+- Hayes-Roth, B. (1984). Stanford Heuristic Programming Project
+  Report No. 84-16; see also Hayes-Roth (1985), *Artificial
+  Intelligence* 26(3), 251-321.
+  [link](http://i.stanford.edu/pub/cstr/reports/cs/tr/84/1034/CS-TR-84-1034.pdf)
+- **What it contributes.** The canonical blackboard-architecture
+  paper. Defines a domain blackboard, a separate control blackboard,
+  independent knowledge sources that read and write the blackboards,
+  and a scheduler that uses control heuristics recorded on the
+  control blackboard to pick the next action. Forty-plus years on,
+  it is still the cleanest framing of "no direct messaging between
+  agents, only writes to a shared artifact."
+- **Seen elsewhere.** HEARSAY-II speech understanding, classical
+  expert systems, most modern workflow engines that use a shared
+  state store instead of message queues. The "event store + handlers"
+  pattern in distributed systems is a lineal descendant.
+- **Inspires in Formica.**
+  - The Forum (Neo4j graph) is the domain blackboard. There is
+    deliberately no second control blackboard - Formica folds
+    control into pheromone gradients on the same graph, which
+    Rodriguez 2026 argues is sufficient and lower-overhead.
+  - Castes map to knowledge sources: each caste reads a
+    well-defined slice of the graph and writes a well-defined set
+    of node or edge types. No caste reads another caste's
+    scratchpad.
+
+## Distributed algorithms inspired by ants
+
+### Distributed algorithms from arboreal ants for the shortest path problem
+
+- Garg, S., Shiragur, K., Gordon, D. M., Charikar, M. (2023). *PNAS*
+  120(6), e2207959120.
+  [link](https://www.pnas.org/doi/10.1073/pnas.2207959120) ·
+  [code](https://github.com/shivamg13/Arboreal-Ants)
+- **What it contributes.** A biologically plausible reinforced
+  random walk that converges to the minimum-leakage path under
+  constant flow and to the shortest path under increasing flow, with
+  a linear decision rule. The convergence proofs require
+  bidirectional flow and proportional-to-pheromone edge selection;
+  nonlinear decision rules still improve on baselines in >80% of
+  simulations but lose formal guarantees. Strictly distinct from
+  ant-colony optimization (ACO): no individual memory, no
+  retracing.
+- **Seen elsewhere.** The linear-rule + bidirectional-flow
+  combination shows up in network routing under the name "valiant
+  load balancing" and in some consensus protocols where probabilistic
+  preference for higher-weighted edges yields convergence without a
+  coordinator.
+- **Inspires in Formica.**
+  - The pheromone update step in the Forum - "add on traversal,
+    multiply by decay each tick" - is the paper's equation 3
+    applied to task-graph edges instead of physical vine edges.
+  - The `promising` and `validated` pheromone channels implement
+    bidirectional flow: foragers lay `promising` going in, validators
+    lay `validated` coming out. The combination is what the paper
+    shows is necessary for convergence.
+  - The phase-cycling rule "increase activity when entropy drops"
+    is inspired by the paper's result that *increasing* flow rate
+    converts minimum-leakage convergence into shortest-path
+    convergence.
+
+### A distributed algorithm to maintain and repair the trail networks of arboreal ants
+
+- Chandrasekhar, A., Gordon, D. M., Navlakha, S. (2018). *Scientific
+  Reports* 8, 9297.
+  [link](https://www.nature.com/articles/s41598-018-27160-3)
+- **What it contributes.** The RankEdge random walk: rank outgoing
+  edges by pheromone weight, pick within rank-ties uniformly, use
+  explore probability `q_explore ^ i` for the i-th rank. Field-fit
+  parameters: `q_decay = 0.02`, `q_explore = 0.20`. Four design
+  choices the paper proves are necessary for good repair behavior:
+  (1) bidirectional concurrent search from both sides of a break,
+  (2) no backtracking to immediate previous node, (3) no pheromone
+  on return from dead ends, (4) one-ant-per-node-per-timestep
+  queueing. Achieves 70% repair success on Full grid topologies.
+- **Seen elsewhere.** Self-healing overlay networks (Chord, Kademlia
+  after churn), gossip protocols with anti-entropy repair, BGP
+  convergence after link failures. The "no pheromone on dead-end
+  return" trick is the same insight as negative acknowledgment in
+  transport protocols.
+- **Inspires in Formica.**
+  - The `dead-end` pheromone channel is a direct port of the
+    dead-end non-marking rule: when a Forager's evidence is rejected
+    by a Validator, the edge it walked is marked `dead-end` rather
+    than reinforced as `promising`.
+  - The alarm pheromone (short half-life, preempts work) plays the
+    role of rapid bidirectional search around a break: when an
+    alarm lands on a subproblem, agents retreat and alternative
+    branches are reweighted upward.
+  - The "no backtracking" constraint maps to Formica's rule that an
+    agent cannot immediately re-walk the edge it came in on during
+    a single task.
+
+### The Anternet: harvester ant traffic control
+
+- Prabhakar, B., Dektar, K., Gordon, D. M. (2012). "The Regulation
+  of Ant Colony Foraging Activity without Spatial Information."
+  *PLoS Computational Biology* 8(8), e1002670. Reported for a
+  general audience by Stanford Engineering as "Stanford biologist
+  and computer scientist discover the 'anternet.'"
+  [report](https://engineering.stanford.edu/news/stanford-biologist-and-computer-scientist-discover-anternet) ·
+  [paper](https://doi.org/10.1371/journal.pcbi.1002670)
+- **What it contributes.** Shows that harvester-ant foraging
+  activity is regulated by the rate at which returning foragers
+  arrive at the nest, in a feedback loop mathematically equivalent
+  to TCP congestion control. Foragers slow their outbound rate when
+  the return rate drops, which is exactly the additive-increase /
+  multiplicative-decrease pattern on the Internet.
+- **Seen elsewhere.** TCP itself. The AIMD family more broadly
+  (CUBIC, BBR's probing behavior). The autoscaler in HPA with
+  target-utilization.
+- **Inspires in Formica.**
+  - `formica/coordinator/anternet.py` - the "anternet signal" that
+    scales spawn rate based on the recent ratio of validated
+    evidence mass to compute-seconds consumed. Named after this
+    paper explicitly.
+  - The controller's backpressure rule ("if pending pods exceed
+    threshold, throttle spawn") is the multiplicative-decrease half
+    of AIMD applied to caste pool sizes.
+
+## Stigmergy and colony behavior
+
+### Encounter Rate and Task Allocation in Harvester Ants
+
+- Gordon, D. M., Mehdiabadi, N. J. (1999). *Behavioral Ecology and
+  Sociobiology* 45, 370-377.
+  [link](https://web.stanford.edu/~dmgordon/previous/GordonMehdiabadi1999.pdf)
+- **What it contributes.** The empirical basis for what Formica
+  calls "Gordon's rule." Shows that an individual ant's probability
+  of switching tasks is driven by the *rate* of its brief antennal
+  encounters with workers engaged in another task, not by any global
+  signal or count. Ants cannot assess total colony state; local
+  encounter rate is sufficient. This is the original no-central-
+  control result for insect task allocation, and the paper the
+  colony-behavior section of the Active Inferants paper below
+  builds on.
+- **Seen elsewhere.** Nothing in distributed systems cites this
+  directly, but every gossip-based membership protocol implements
+  the same idea: local rates of "I heard from X recently" drive
+  global state estimates.
+- **Inspires in Formica.**
+  - The role-reallocation logic in `formica/capacity/pools.py`:
+    agents re-specialize based on local encounter rates with peers
+    of other castes, not on a global "we need more validators"
+    signal. The "Gordon's rule" name in the README points here.
+  - The alarm pheromone's short half-life is calibrated so that it
+    behaves like an encounter rate: spikes quickly, decays quickly,
+    pressures nearby agents into the "respond to failure" task
+    without a dispatcher.
+
+### Active Inferants: An Active Inference Framework for Ant Colony Behavior
+
+- Friedman, D. A., Tschantz, A., Ramstead, M. J. D., Friston, K.,
+  Constant, A. (2021). *Frontiers in Behavioral Neuroscience* 15,
+  647732.
+  [link](https://www.frontiersin.org/journals/behavioral-neuroscience/articles/10.3389/fnbeh.2021.647732/full)
+- **What it contributes.** Recasts ant colony foraging as active
+  inference: each ant minimizes free energy over a generative model
+  of the environment, the colony's stigmergic traces collectively
+  constitute an extended-cognition substrate, and multiscale
+  Bayesian inference unifies nestmate-, colony-, and population-
+  scale behaviors. Connects the stigmergy literature with the
+  Friston / free-energy-principle program.
+- **Seen elsewhere.** Predictive-coding models of perception,
+  world-models in reinforcement learning (Dreamer, etc.), and the
+  "belief propagation on a shared graph" pattern in probabilistic
+  robotics.
+- **Inspires in Formica.**
+  - The distinction in `docs/architecture.md` between "local belief
+    written to the graph" (what an agent records) and "colony
+    belief emerging from the pheromone field" (what the controller
+    and downstream agents read) is the nestmate / colony scale
+    split from this paper.
+  - The Validator's role as an inference step rather than a
+    gatekeeper: it does not approve or reject in a single step; it
+    emits a `validated` pheromone that accumulates, and consensus
+    emerges from many Validators' contributions. This is the
+    paper's "inference as accumulated evidence" framing.
+
+### Evolution of self-organised division of labour driven by stigmergy in leaf-cutter ants
+
+- Govoni, P. et al. (2022). *Scientific Reports* 12, 22338.
+  [link](https://www.nature.com/articles/s41598-022-26324-6)
+- **What it contributes.** Agent-based model of leaf-cutter
+  arboreal foraging where task partitioning (droppers vs
+  collectors) evolves from a generalist baseline via independent
+  mutations in two probabilities (P\_D, P\_P). Shows task
+  partitioning is favored in tall-tree environments and emerges
+  without pleiotropy, simultaneous mutations, or morphological
+  differentiation. Dropped leaves act as the stigmergic stimulus;
+  cache dynamics form an integral-control loop with oscillations.
+- **Seen elsewhere.** The evolutionary-origin-of-specialization
+  result parallels arguments in the division-of-labour literature
+  for robot swarms (e.g. the "threshold reinforcement" family of
+  models).
+- **Inspires in Formica.**
+  - Evidence in the Forum plays the role of "dropped leaves":
+    Foragers produce, Validators consume, and the depth of the
+    unvalidated-evidence queue is the integral-control signal that
+    drives Gordon reallocation.
+  - The Scout / Forager / Validator split is not hard-coded in
+    principle - this paper is the argument that specialization can
+    *evolve* from a generalist pool given the right cache dynamics.
+    A future enhancement (tracked in project issues) would let pool
+    sizes evolve from a single undifferentiated pool instead of
+    being declared.
+
+### Stigmergic construction and topochemical information shape ant nest architecture
+
+- Khuong, A., Gautrais, J., Perna, A., Sbaï, C., Combe, M., Kuntz,
+  P., Jost, C., Theraulaz, G. (2016). *PNAS* 113(5), 1303-1308.
+  [link](https://pmc.ncbi.nlm.nih.gov/articles/PMC4747701/)
+- **What it contributes.** Shows that *Lasius niger* nest
+  architecture (regular pillar spacing, cap formation, arch
+  merging) is fully explained by two interactions: a stigmergic
+  amplification via pheromone-laced building material and a
+  template interaction where ants use their body size as a height
+  cue. 3D stochastic model reproduces field observations. Key
+  parameter: pheromone lifetime. Too short, no structures; too
+  long, saturation and merging collapse. Optimum is
+  800-1,200 seconds for this species.
+- **Seen elsewhere.** Procedural generation in games, morphogenesis
+  models in biology (reaction-diffusion systems), and the
+  "topological defects as structure" idea in condensed-matter
+  physics.
+- **Inspires in Formica.**
+  - The six separate pheromone channels with *different* half-lives
+    is a direct generalization of this paper's "pheromone lifetime
+    controls form." Short half-life on `alarm` means alarm
+    structures stay local; long half-life on `validated` means
+    validated subgraphs persist as stable structure. The parameter
+    tuning in `deploy/helm/formica/values.yaml` under `pheromones:`
+    was calibrated against this paper's lifetime-vs-structure
+    curves.
+  - The template interaction (body size as a cue) has no Formica
+    equivalent yet. A proposed feature (tracked in project issues)
+    would use per-pool resource requests as a "body size" cue:
+    Scouts with small resource requests naturally create different
+    graph topology than Validators with larger ones.
+
+## Formica-specific biology
+
+These last two are not about computation at all, but they are what
+justifies the "Formica" name over, say, "Atta" or "Pogonomyrmex."
+
+### The evolution of social parasitism in Formica ants revealed by a global phylogeny
+
+- Borowiec, M. L., Cover, S. P., Rabeling, C. (2021). *PNAS*
+  118(38), e2026029118.
+  [link](https://pubmed.ncbi.nlm.nih.gov/34535549/)
+- **What it contributes.** Phylogeny of 172 *Formica* species
+  showing that half are confirmed or suspected social parasites.
+  Documents three parasitism classes (temporary, dulotic, permanent
+  inquilinism), with permanent inquilinism evolving twice from
+  temporary-parasite ancestors. Shows that obligate social
+  parasitism can arise from a facultative-parasitism background via
+  allopatric speciation.
+- **Seen elsewhere.** The social-parasitism literature more broadly
+  (cuckoos, brood parasites), but *Formica*'s diversity is
+  unusually rich.
+- **Inspires in Formica.**
+  - The Inquiline caste (`formica/agents/inquiline/`) takes its
+    name from this paper's "permanent inquilines" - narrow,
+    specialized agents that live inside the colony and do one thing
+    (citation checking, numeric sanity) without being part of the
+    main scout-forager-validator flow.
+  - The design freedom to add more Inquilines later without
+    changing the main castes is modeled on how inquiline species
+    in *Formica* integrate into host colonies without disrupting
+    host caste structure.
+
+### Untangling the Interplay Among Navigational Strategies Used by the Ant *Formica podzolica*
+
+- Dias, C. M., Breed, M. D. (2008). *Annals of the Entomological
+  Society of America* 101(6), 1145-1149.
+  [link](https://academic.oup.com/aesa/article-abstract/101/6/1145/2758531)
+- **What it contributes.** Shows that *Formica podzolica* foragers
+  use multiple simultaneous navigation cues - pheromone trails,
+  landmarks, compass bearings, visual scene snapshots, polarized
+  light - rather than any single signal. Establishes that real ant
+  navigation is multi-signal and context-dependent.
+- **Seen elsewhere.** Sensor fusion in robotics, the "mixture of
+  experts" pattern in ML, multi-modal retrieval in modern RAG
+  systems.
+- **Inspires in Formica.**
+  - The six pheromone channels (rather than a single "weight")
+    follow this paper's core insight: navigation is multi-signal.
+    `promising`, `validated`, `risky`, `needs-expert`, `dead-end`,
+    `alarm` are independent channels an agent can weigh
+    differently based on caste and context.
+  - The caste-specific attention weights (documented in
+    `docs/pheromones.md`) implement the "weighted combination of
+    signals" described in the paper's discussion.
+
+## Also worth reading
+
+### An experimental study of the foraging strategy of the wood ant *Formica rufa*
+
+- Cherix, D. (1987). *Animal Behaviour* 35(5), 1520-1535.
+  [link](https://www.sciencedirect.com/science/article/pii/S0003347285800774)
+- Classic empirical grounding for foraging and recruitment behavior
+  in *Formica rufa*, the species the genus is named after. Not
+  directly cited by a specific Formica component, but sits behind
+  the general shape of the Forager caste's recruitment behavior.
+
+### Foraging Strategies of Ants (review)
+
+- Traniello, J. F. A. (1989). *Annual Review of Entomology* 34,
+  191-210.
+  [link](https://www.annualreviews.org/doi/10.1146/annurev.en.34.010189.001203)
+- Canonical review article surveying the full taxonomy of ant
+  foraging strategies (solitary, tandem running, group recruitment,
+  short-term trails, trunk trails, long-term networks, raiding).
+  Useful context for anyone extending Formica with new caste types;
+  most of the options have been field-tested by real ant species.

--- a/docs/single-box.md
+++ b/docs/single-box.md
@@ -1,8 +1,8 @@
 # Single-box Formica (k3d on a GPU EC2 instance)
 
 Formica runs the same Kubernetes manifests whether you have one node or
-fifty. For single-box development, we use [k3d](https://k3d.io/) — a
-lightweight k3s cluster that runs inside Docker on a single host — so
+fifty. For single-box development, we use [k3d](https://k3d.io/) - a
+lightweight k3s cluster that runs inside Docker on a single host - so
 you exercise the real controller / Job / Service / RBAC path on your
 laptop or on a single GPU EC2 box.
 
@@ -59,7 +59,7 @@ From outside the cluster (e.g. the EC2 instance's shell):
 ```bash
 pip install -e ".[dev]"
 
-# The CLI is a thin client — it writes to Neo4j and polls. The colony
+# The CLI is a thin client - it writes to Neo4j and polls. The colony
 # lives in the cluster. Port-forward Neo4j and vLLM so local env vars
 # Just Work.
 kubectl -n formica port-forward svc/neo4j 7687:7687 &
@@ -80,12 +80,12 @@ emit it.
 # Controller decisions (spawn/retire/phase transitions).
 kubectl -n formica logs -f deploy/formica-controller
 
-# Live pod list — scouts, foragers, validators, gc appear and disappear
+# Live pod list - scouts, foragers, validators, gc appear and disappear
 # as the controller reallocates roles.
 watch kubectl -n formica get pods
 
 # Neo4j browser (pheromones, subproblem graph).
-# neo4j / changeme  — override via deploy/k8s/base/neo4j.yaml for prod.
+# neo4j / changeme  - override via deploy/k8s/base/neo4j.yaml for prod.
 open http://localhost:7474
 ```
 
@@ -100,7 +100,7 @@ with the cluster, so this is a clean reset.
 
 ## From k3d to EKS
 
-The exact same manifests work on a real multi-node EKS cluster — that's
+The exact same manifests work on a real multi-node EKS cluster - that's
 the whole point. You only need to swap two things:
 
 1. **vLLM weights.** The `vllm.yaml` base manifest uses a `hostPath`

--- a/formica/__init__.py
+++ b/formica/__init__.py
@@ -1,3 +1,3 @@
-"""Formica — stigmergic, ant-colony-inspired multi-agent problem solving."""
+"""Formica - stigmergic, ant-colony-inspired multi-agent problem solving."""
 
 __version__ = "0.1.0"

--- a/formica/agents/base.py
+++ b/formica/agents/base.py
@@ -1,4 +1,4 @@
-"""Base Agent class — the tick loop.
+"""Base Agent class - the tick loop.
 
 Every caste runs: read_local_neighborhood → act → write_back, with OTEL spans
 emitted for every step.

--- a/formica/agents/entrypoint.py
+++ b/formica/agents/entrypoint.py
@@ -1,7 +1,7 @@
 """Container entrypoint for caste pods.
 
 Reads FORMICA_COMPONENT to pick the caste and runs a bounded number of ticks.
-Short-lived by design — the controller spawns replacements.
+Short-lived by design - the controller spawns replacements.
 """
 
 from __future__ import annotations

--- a/formica/agents/forager.py
+++ b/formica/agents/forager.py
@@ -1,4 +1,4 @@
-"""Forager caste — picks a SubProblem by gradient, produces Evidence."""
+"""Forager caste - picks a SubProblem by gradient, produces Evidence."""
 
 from __future__ import annotations
 
@@ -107,7 +107,7 @@ class Forager(Agent):
             return (resp.get("content") or "").strip(), list(resp.get("sources") or [])
         except Exception:
             # Deterministic fallback for tests.
-            return (f"Observation: {task_text} — preliminary analysis.", [])
+            return (f"Observation: {task_text} - preliminary analysis.", [])
 
 
 def _has_label(node: dict, label: str) -> bool:

--- a/formica/agents/gc.py
+++ b/formica/agents/gc.py
@@ -1,4 +1,4 @@
-"""Garbage collector caste (Lustrum) — necrophoresis.
+"""Garbage collector caste (Lustrum) - necrophoresis.
 
 Prunes nodes whose aggregate pheromone mass is below a floor, after their last
 update is older than a grace period.

--- a/formica/agents/inquiline/__init__.py
+++ b/formica/agents/inquiline/__init__.py
@@ -1,4 +1,4 @@
-"""Inquilines — narrow specialists that activate only on specific pheromone patterns."""
+"""Inquilines - narrow specialists that activate only on specific pheromone patterns."""
 
 from formica.agents.inquiline.citation_checker import CitationChecker
 from formica.agents.inquiline.numeric_sanity import NumericSanityChecker

--- a/formica/agents/inquiline/citation_checker.py
+++ b/formica/agents/inquiline/citation_checker.py
@@ -1,4 +1,4 @@
-"""Citation-checker inquiline — runs only on Evidence with `needs-expert` and sources."""
+"""Citation-checker inquiline - runs only on Evidence with `needs-expert` and sources."""
 
 from __future__ import annotations
 

--- a/formica/agents/inquiline/numeric_sanity.py
+++ b/formica/agents/inquiline/numeric_sanity.py
@@ -1,4 +1,4 @@
-"""Numeric-sanity inquiline — checks arithmetic claims in Evidence content."""
+"""Numeric-sanity inquiline - checks arithmetic claims in Evidence content."""
 
 from __future__ import annotations
 

--- a/formica/agents/scout.py
+++ b/formica/agents/scout.py
@@ -1,4 +1,4 @@
-"""Scout caste — decomposes an Objective or SubProblem into new SubProblems."""
+"""Scout caste - decomposes an Objective or SubProblem into new SubProblems."""
 
 from __future__ import annotations
 
@@ -32,7 +32,7 @@ class Scout(Agent):
         if not parent_id or not parent_text:
             return AgentResult(action="scout.no-op", notes="no focus")
 
-        # LLM call is optional — a deterministic fallback lets us run without a model
+        # LLM call is optional - a deterministic fallback lets us run without a model
         # (e.g. unit tests, the toy math e2e).
         subproblem_texts = self._decompose(parent_text)
 

--- a/formica/agents/validator.py
+++ b/formica/agents/validator.py
@@ -1,4 +1,4 @@
-"""Validator caste (Censors) — verify Evidence nodes."""
+"""Validator caste (Censors) - verify Evidence nodes."""
 
 from __future__ import annotations
 

--- a/formica/blackboard/__init__.py
+++ b/formica/blackboard/__init__.py
@@ -1,4 +1,4 @@
-"""The Forum — Neo4j blackboard DAL."""
+"""The Forum - Neo4j blackboard DAL."""
 
 from formica.blackboard.forum import Forum
 from formica.blackboard.models import (

--- a/formica/blackboard/forum.py
+++ b/formica/blackboard/forum.py
@@ -1,4 +1,4 @@
-"""The Forum — Neo4j-backed blackboard DAL.
+"""The Forum - Neo4j-backed blackboard DAL.
 
 Every agent interaction goes through this class. It is the only place in the
 codebase that should talk to Neo4j directly.

--- a/formica/cli.py
+++ b/formica/cli.py
@@ -25,7 +25,7 @@ log = get_logger(__name__)
 
 @click.group()
 def main() -> None:
-    """Formica — stigmergic multi-agent problem solving."""
+    """Formica - stigmergic multi-agent problem solving."""
 
 
 @main.command()
@@ -41,8 +41,8 @@ def solve(problem: str, budget: float, timeout: int, env: str, region: str,
     """Submit an Objective to the Forum and wait for validated Evidence.
 
     The CLI is a thin client: it writes the Objective to the Forum (Neo4j)
-    and polls for validated Evidence. The actual colony — controller,
-    scouts, foragers, validators, GC — runs as Kubernetes workloads.
+    and polls for validated Evidence. The actual colony - controller,
+    scouts, foragers, validators, GC - runs as Kubernetes workloads.
     For single-box use, bring up a k3d cluster (see docs/single-box.md);
     the same manifests then work unchanged on a real EKS cluster.
     """

--- a/formica/pheromones/constants.py
+++ b/formica/pheromones/constants.py
@@ -16,7 +16,7 @@ class PheromoneChannel(str, Enum):
 
 CHANNELS = tuple(c.value for c in PheromoneChannel)
 
-# Half-lives (seconds) — override in production via env vars or Helm.
+# Half-lives (seconds) - override in production via env vars or Helm.
 DEFAULT_HALF_LIFE: dict[str, int] = {
     PheromoneChannel.PROMISING.value: 15 * 60,
     PheromoneChannel.VALIDATED.value: 60 * 60,

--- a/formica/tools/aws_exec.py
+++ b/formica/tools/aws_exec.py
@@ -1,4 +1,4 @@
-"""AWS MCP exec tool — run commands on **existing** EC2/GPU instances only.
+"""AWS MCP exec tool - run commands on **existing** EC2/GPU instances only.
 
 This tool must NEVER provision new instances. It only runs shell commands on
 instances that already exist in the account. SSM `SendCommand` is the transport.

--- a/formica/tools/llm.py
+++ b/formica/tools/llm.py
@@ -1,4 +1,4 @@
-"""Strands agent wrapper used by castes — returns parsed JSON."""
+"""Strands agent wrapper used by castes - returns parsed JSON."""
 
 from __future__ import annotations
 

--- a/tests/e2e/test_toy_math.py
+++ b/tests/e2e/test_toy_math.py
@@ -1,4 +1,4 @@
-"""End-to-end style test — drives a toy math problem through the tick loop
+"""End-to-end style test - drives a toy math problem through the tick loop
 against the in-memory FakeForum. Verifies that:
 
   1. Scouts decompose the objective.
@@ -39,7 +39,7 @@ def test_toy_math_converges(monkeypatch):
     evs = [n for n in forum.nodes.values() if "Evidence" in n["_labels"]]
     assert len(evs) == len(subs)
 
-    # 3) Validator verdicts — force `validated` by monkeypatching _judge.
+    # 3) Validator verdicts - force `validated` by monkeypatching _judge.
     def _always_validate(self, content, sources):
         return "validated", 0.95, "forced-pass for test"
 

--- a/tests/integration/test_tick_loop.py
+++ b/tests/integration/test_tick_loop.py
@@ -15,7 +15,7 @@ from formica.config import FormicaConfig
 
 
 class FakeForum:
-    """In-memory Forum — enough of the API for the tick loop."""
+    """In-memory Forum - enough of the API for the tick loop."""
 
     def __init__(self):
         self.nodes: dict[str, dict] = {}

--- a/tests/unit/test_capacity_math.py
+++ b/tests/unit/test_capacity_math.py
@@ -1,4 +1,4 @@
-"""Capacity math — pool budgeting and headroom. Never provisions."""
+"""Capacity math - pool budgeting and headroom. Never provisions."""
 
 from formica.capacity.headroom import ClusterHeadroom, NodeSnapshot
 from formica.capacity.pools import Pool, budget
@@ -59,7 +59,7 @@ def test_passive_expansion_detected():
     added = _h([NodeSnapshot(name="new", allocatable_cpu_millis=2000,
                              allocatable_memory_bytes=4 * 1024**3)])
     b2 = budget(p, added, desired=4)
-    # The controller immediately uses the new headroom — no config change.
+    # The controller immediately uses the new headroom - no config change.
     assert b2.allowed_spawn > 0
 
 

--- a/tests/unit/test_numeric_sanity.py
+++ b/tests/unit/test_numeric_sanity.py
@@ -1,4 +1,4 @@
-"""Numeric sanity inquiline — pure-Python path (no Neo4j)."""
+"""Numeric sanity inquiline - pure-Python path (no Neo4j)."""
 
 from formica.agents.inquiline.numeric_sanity import _EQ_RE, _check
 


### PR DESCRIPTION
Stacks on top of #1.

## README
- Dropped the 'What's different from Rome' section and the 'Roman aliases' table. Rome isn't public to new readers, so the comparison is noise.
- Kept a renamed 'What is Formica' section that explains Forum / pheromones / castes / Gordon / phase cycling / alarm / capacity awareness on its own terms.
- Added a Mermaid architecture diagram (renders natively on GitHub) showing: CLI as thin client, controller spawning castes within cluster headroom, castes coordinating only through Neo4j + calling vLLM, telemetry flowing to CloudWatch + S3/Athena.
- Reworked launch into numbered steps: prerequisites, create k3d cluster, deploy Formica, submit an objective, watch the colony, then the EKS overlay as a one-liner.

## Em-dashes
89 U+2014 characters replaced with ASCII `-` across 36 files (docs, code comments, one workflow). ' - ' (with spaces) where the em-dash was parenthetical; '-' otherwise.

## Tests
All 39 still pass.