### PR TITLE
fix(kustomize): wrap sibling dirs as bases; migrate commonLabels

### DIFF
--- a/deploy/fluent-bit/kustomization.yaml
+++ b/deploy/fluent-bit/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - fluent-bit.yaml

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -7,8 +7,10 @@ resources:
   - neo4j.yaml
   - controller.yaml
   - evaporation-cron.yaml
-  - ../../otel-collector/collector.yaml
-  - ../../fluent-bit/fluent-bit.yaml
+  - ../../otel-collector
+  - ../../fluent-bit
 
-commonLabels:
-  app.kubernetes.io/instance: formica
+labels:
+  - pairs:
+      app.kubernetes.io/instance: formica
+    includeSelectors: true

--- a/deploy/otel-collector/kustomization.yaml
+++ b/deploy/otel-collector/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - collector.yaml


### PR DESCRIPTION
Pre-existing CI failure on `main` and every feature branch.

### Problem

The `helm-kustomize` job fails with:

```
error: accumulating resources: accumulation err='accumulating
resources from '../../otel-collector/collector.yaml': security;
file '/deploy/otel-collector/collector.yaml' is not in or below
'/deploy/k8s/base''
```

Kustomize disallows referencing files outside a base directory.
`deploy/k8s/base/kustomization.yaml` was pointing at
`../../otel-collector/collector.yaml` and
`../../fluent-bit/fluent-bit.yaml`, which trips that rule.

The same job also emits:

```
Warning: 'commonLabels' is deprecated. Please use 'labels' instead.
```

### Fix

- Add `deploy/otel-collector/kustomization.yaml` wrapping
  `collector.yaml`.
- Add `deploy/fluent-bit/kustomization.yaml` wrapping
  `fluent-bit.yaml`.
- `deploy/k8s/base/kustomization.yaml` now references the two
  directories (allowed) instead of the raw files (not allowed).
- Migrate `commonLabels` to the newer `labels` form with
  `includeSelectors: true`, preserving the exact behaviour of the
  previous config.

### Verification

Ran `kustomize v5.4.3 build` locally on both overlays:

```
$ kustomize build deploy/k8s/overlays/dev  | wc -l
652
$ kustomize build deploy/k8s/overlays/prod | wc -l
652
```

No warnings. Spot-checked that `app.kubernetes.io/instance: formica`
still appears in every Service selector and Deployment/StatefulSet
`matchLabels`, so the label contract is unchanged.

### Why this goes to `main` first

This is a pre-existing bug that affects CI on `main` itself (see the
most recent push-to-main run). Merging this directly to `main` turns
CI green for the base and for every stacked PR once rebased.
