### PR TITLE
Switch single-box from k3d to bare k3s; document AWS launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,61 +95,42 @@ no Docker-in-the-middle, and no in-process mode.
 - For AWS observability: valid AWS credentials in the shell that runs
   `kubectl apply` (IRSA handles pod-level auth once deployed).
 
-### 1. Create a single-node GPU cluster
+### Single box on EC2 (one command)
+
+Launch a `g5.xlarge` on the rome AMI (`ami-079c82d610e02e480`) with a
+**200 GB gp3 root volume** and an instance profile carrying
+`AmazonSSMManagedInstanceCore`, then:
 
 ```bash
-# Install k3s as a systemd service. k3s v1.34+ auto-registers
-# nvidia-container-runtime when it finds it in PATH.
-curl -sfL https://get.k3s.io | \
-  INSTALL_K3S_EXEC="--disable=traefik --write-kubeconfig-mode=644" sh -
-
-# Register the nvidia RuntimeClass.
-cat <<'YAML' | sudo k3s kubectl apply -f -
-apiVersion: node.k8s.io/v1
-kind: RuntimeClass
-metadata: { name: nvidia }
-handler: nvidia
-YAML
-
-# Install the NVIDIA device plugin and pin it to the nvidia runtime.
-sudo k3s kubectl apply -f \
-  https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml
-sudo k3s kubectl -n kube-system patch daemonset nvidia-device-plugin-daemonset \
-  --type=json \
-  -p '[{"op":"add","path":"/spec/template/spec/runtimeClassName","value":"nvidia"}]'
+aws ssm start-session --target i-XXXXXXXXXXXXXXXXX --region us-east-1
+sudo su - ec2-user
+git clone https://github.com/abacus2000/formica.git ~/formica
+cd ~/formica
+bash scripts/launch-single-box.sh
 ```
 
-### 2. Deploy Formica
+The script installs k3s + the NVIDIA device plugin, builds
+`formica:latest` into k3s's containerd store via BuildKit, deploys the
+dev overlay, waits for everything to roll out, and runs a `formica
+solve` smoke test. It takes ~10 minutes on a fresh instance, is
+idempotent, and refuses to run on a root volume that cannot fit the
+vLLM image.
+
+Knobs: `SKIP_SMOKE=1` stops after the rollout. Full documentation,
+including a manual step-by-step and troubleshooting, is in
+[`docs/launch-on-aws.md`](docs/launch-on-aws.md).
+
+### Submit more objectives
+
+The launcher leaves port-forwards running and env vars exported in its
+shell. From any new shell:
 
 ```bash
-git clone https://github.com/abacus2000/formica.git && cd formica
-# Build the controller image into k3s's containerd image store.
-# See docs/launch-on-aws.md for the BuildKit setup.
-sudo buildctl build \
-  --frontend dockerfile.v0 \
-  --local context=. --local dockerfile=. \
-  --output type=image,name=docker.io/library/formica:latest
-
-sudo k3s kubectl apply -k deploy/k8s/overlays/dev
-sudo k3s kubectl -n formica rollout status deploy/vllm --timeout=20m
-```
-
-The `vllm` rollout is the slow one: ~10 GB image pull plus 60-120s
-model load from pre-staged AWQ weights. The controller, Neo4j, and
-OTEL collector come up in seconds.
-
-### 3. Submit an objective
-
-```bash
-pip install -e ".[dev]"
-
-# Port-forward Neo4j and vLLM so the CLI can reach them from outside
-# the cluster.
-kubectl -n formica port-forward svc/neo4j 7687:7687 &
-kubectl -n formica port-forward svc/vllm  8080:8080 &
-
+export KUBECONFIG=$HOME/.kube/config
 export FORMICA_NEO4J_URI=bolt://localhost:7687
 export FORMICA_MODEL_BASE_URL=http://localhost:8080/v1
+kubectl -n formica port-forward svc/neo4j 7687:7687 &
+kubectl -n formica port-forward svc/vllm  8080:8080 &
 
 formica solve "Prove sqrt(2) is irrational" --budget 1 --timeout 600
 ```
@@ -176,6 +157,7 @@ formica solve "Prove sqrt(2) is irrational with three independent methods" \
 ```
 
 Step-by-step EC2 recipe: [`docs/launch-on-aws.md`](docs/launch-on-aws.md).
+Automated launcher: [`scripts/launch-single-box.sh`](scripts/launch-single-box.sh).
 Conceptual walkthrough: [`docs/single-box.md`](docs/single-box.md).
 
 ## Observability

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ graph with pheromone-weighted edges, stored in Neo4j.
 flowchart LR
     CLI["formica solve<br/>(thin client)"]
 
-    subgraph cluster["Kubernetes cluster (k3d or EKS)"]
+    subgraph cluster["Kubernetes cluster (k3s or EKS)"]
         direction TB
 
         CTRL["Controller<br/>capacity-aware<br/>spawn / retire"]
@@ -81,12 +81,13 @@ within whatever cluster headroom happens to exist.
 ## Launch
 
 Formica is Kubernetes-native end-to-end. The same manifests work on a
-single box (via [k3d](https://k3d.io/)) and on a real EKS cluster.
-There is no separate Docker Compose stack and no in-process mode.
+single box (bare [k3s](https://k3s.io/) installed as a systemd service)
+and on a real EKS cluster. There is no separate Docker Compose stack,
+no Docker-in-the-middle, and no in-process mode.
 
 ### Prerequisites
 
-- Docker, `kubectl`, `kustomize`, and `k3d` on your PATH.
+- `curl`, `systemd`, and root access to install k3s.
 - For local GPU inference: an NVIDIA GPU with drivers and
   `nvidia-container-toolkit` installed, plus Mistral-7B-AWQ weights at
   `/opt/models/mistral-awq` on the host. (Skip this if you override to
@@ -97,28 +98,45 @@ There is no separate Docker Compose stack and no in-process mode.
 ### 1. Create a single-node GPU cluster
 
 ```bash
-k3d cluster create formica \
-  --gpus all \
-  --volume "/opt/models:/opt/models@all" \
-  --port "8080:8080@loadbalancer" \
-  --port "7474:7474@loadbalancer" \
-  --port "7687:7687@loadbalancer"
+# Install k3s as a systemd service. k3s v1.34+ auto-registers
+# nvidia-container-runtime when it finds it in PATH.
+curl -sfL https://get.k3s.io | \
+  INSTALL_K3S_EXEC="--disable=traefik --write-kubeconfig-mode=644" sh -
 
-kubectl apply -f \
-  https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.15.0/deployments/static/nvidia-device-plugin.yml
+# Register the nvidia RuntimeClass.
+cat <<'YAML' | sudo k3s kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata: { name: nvidia }
+handler: nvidia
+YAML
+
+# Install the NVIDIA device plugin and pin it to the nvidia runtime.
+sudo k3s kubectl apply -f \
+  https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml
+sudo k3s kubectl -n kube-system patch daemonset nvidia-device-plugin-daemonset \
+  --type=json \
+  -p '[{"op":"add","path":"/spec/template/spec/runtimeClassName","value":"nvidia"}]'
 ```
 
 ### 2. Deploy Formica
 
 ```bash
 git clone https://github.com/abacus2000/formica.git && cd formica
-kubectl apply -k deploy/k8s/overlays/dev
-kubectl -n formica rollout status deploy/vllm --timeout=15m
+# Build the controller image into k3s's containerd image store.
+# See docs/launch-on-aws.md for the BuildKit setup.
+sudo buildctl build \
+  --frontend dockerfile.v0 \
+  --local context=. --local dockerfile=. \
+  --output type=image,name=docker.io/library/formica:latest
+
+sudo k3s kubectl apply -k deploy/k8s/overlays/dev
+sudo k3s kubectl -n formica rollout status deploy/vllm --timeout=20m
 ```
 
-The `vllm` rollout is the slow one (60-120s on the prebaked GPU AMI,
-up to 15 minutes if weights are downloaded from HuggingFace). The
-controller, Neo4j, and OTEL collector come up in seconds.
+The `vllm` rollout is the slow one: ~10 GB image pull plus 60-120s
+model load from pre-staged AWQ weights. The controller, Neo4j, and
+OTEL collector come up in seconds.
 
 ### 3. Submit an objective
 
@@ -157,7 +175,8 @@ formica solve "Prove sqrt(2) is irrational with three independent methods" \
   --budget 2 --timeout 600 --env prod --region us-east-1
 ```
 
-Full walkthrough: [`docs/single-box.md`](docs/single-box.md).
+Step-by-step EC2 recipe: [`docs/launch-on-aws.md`](docs/launch-on-aws.md).
+Conceptual walkthrough: [`docs/single-box.md`](docs/single-box.md).
 
 ## Observability
 

--- a/deploy/k8s/base/neo4j.yaml
+++ b/deploy/k8s/base/neo4j.yaml
@@ -25,6 +25,10 @@ spec:
       labels:
         app.kubernetes.io/component: neo4j
     spec:
+      # Kubernetes auto-injects *_PORT_* env vars for every Service in the
+      # namespace. Neo4j's strict config validator rejects them with
+      # 'Unrecognized setting' and refuses to start. Disable the link injection.
+      enableServiceLinks: false
       containers:
         - name: neo4j
           image: neo4j:5.26.24-community

--- a/deploy/k8s/base/vllm.yaml
+++ b/deploy/k8s/base/vllm.yaml
@@ -1,10 +1,11 @@
 ---
 # vLLM model server. OpenAI-compatible API on :8080.
 #
-# Single-box (k3d on the prebaked GPU AMI): weights are bind-mounted from the
-# host at /opt/models/mistral-awq via a hostPath volume. The GPU is exposed to
-# the pod via the nvidia device plugin (DaemonSet installed by k3d-gpu or the
-# NVIDIA GPU Operator).
+# Single-box (bare k3s on the prebaked GPU AMI): weights are bind-mounted from
+# the host at /opt/models/mistral-awq via a hostPath volume. The GPU is exposed
+# to the pod via the NVIDIA device plugin daemonset. The pod runs under the
+# `nvidia` RuntimeClass so containerd launches it with nvidia-container-runtime,
+# which injects /dev/nvidia*, libraries, and CUDA driver into the container.
 #
 # Multi-node (EKS): replace the hostPath volume with a PVC backed by a model
 # cache (e.g. EFS or an initContainer that rsyncs from S3). The Service name
@@ -27,6 +28,7 @@ spec:
       labels:
         app.kubernetes.io/component: vllm
     spec:
+      runtimeClassName: nvidia
       containers:
         - name: vllm
           image: vllm/vllm-openai:latest

--- a/deploy/k8s/overlays/dev/kustomization.yaml
+++ b/deploy/k8s/overlays/dev/kustomization.yaml
@@ -15,3 +15,28 @@ patches:
       - op: replace
         path: /spec/template/spec/containers/0/env/2/value
         value: us-east-1
+
+  # Swap the prod awss3+parquet exporter for a local debug exporter on dev.
+  # The contrib image ships the awss3 exporter but does not include the
+  # otlp_parquet marshaler (that requires a custom Collector build). The debug
+  # exporter is enough for the single-box smoke test and requires no AWS creds.
+  - target: { kind: ConfigMap, name: otel-collector-config }
+    patch: |-
+      - op: replace
+        path: /data/config.yaml
+        value: |
+          receivers:
+            otlp:
+              protocols:
+                grpc: { endpoint: 0.0.0.0:4317 }
+                http: { endpoint: 0.0.0.0:4318 }
+          processors:
+            batch: {}
+          exporters:
+            debug:
+              verbosity: normal
+          service:
+            pipelines:
+              traces:  { receivers: [otlp], processors: [batch], exporters: [debug] }
+              metrics: { receivers: [otlp], processors: [batch], exporters: [debug] }
+              logs:    { receivers: [otlp], processors: [batch], exporters: [debug] }

--- a/docs/launch-on-aws.md
+++ b/docs/launch-on-aws.md
@@ -1,0 +1,206 @@
+# Launch Formica on a single EC2 GPU box
+
+This is the exact recipe that is known to bring up a working Formica
+cluster on AWS from scratch. It uses the prebaked open-weight AMI from
+the [rome](https://github.com/abacus2000/rome) project, which ships with
+CUDA 13, NVIDIA drivers, `nvidia-container-toolkit`, `nerdctl`, and the
+Mistral-7B-Instruct-v0.2-AWQ weights already staged at
+`/opt/models/mistral-awq`.
+
+If you are on a different AMI, first install drivers and
+`nvidia-container-toolkit` per the
+[NVIDIA docs](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+and stage weights yourself. Everything else below is identical.
+
+## 1. Launch the instance
+
+| Setting             | Value                                             |
+| ------------------- | ------------------------------------------------- |
+| Instance type       | `g5.xlarge` (A10G, 24 GB GPU memory, 4 vCPU, 16 GB RAM) |
+| AMI                 | `ami-079c82d610e02e480` (shared from rome)        |
+| Root volume         | 100 GB gp3 (you will regret anything smaller)     |
+| IAM instance profile| role with `AmazonSSMManagedInstanceCore` attached |
+| Security group      | egress any (pulls from Docker Hub, nvcr.io, GitHub) |
+
+You do not need to open inbound ports. All access is via SSM Session
+Manager or `kubectl port-forward` tunneled over SSH / SSM.
+
+## 2. Connect
+
+```bash
+aws ssm start-session --target i-XXXXXXXXXXXXXXXXX --region us-east-1
+sudo su - ec2-user
+```
+
+Clone the repo:
+
+```bash
+git clone https://github.com/abacus2000/formica.git ~/formica
+cd ~/formica
+```
+
+## 3. Install k3s
+
+```bash
+curl -sfL https://get.k3s.io | \
+  INSTALL_K3S_EXEC="--disable=traefik --write-kubeconfig-mode=644" sh -
+
+# Give kubectl access to the non-root user.
+mkdir -p ~/.kube
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+sudo chown $(id -u):$(id -g) ~/.kube/config
+
+kubectl wait --for=condition=Ready node --all --timeout=120s
+```
+
+Known gotcha: do NOT drop a `config.toml.tmpl` under
+`/var/lib/rancher/k3s/agent/etc/containerd/`. k3s v1.34+ auto-detects
+`nvidia-container-runtime` in `$PATH` and registers it. Adding your own
+template causes containerd to fail with
+`toml: table nvidia already exists` and the node never becomes Ready.
+
+## 4. Expose the GPU to pods
+
+```bash
+# 4a. Register the RuntimeClass.
+cat <<'YAML' | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: nvidia
+handler: nvidia
+YAML
+
+# 4b. Install the NVIDIA device plugin.
+kubectl apply -f \
+  https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml
+
+# 4c. Pin the plugin to the nvidia runtime. Without this it cannot see
+#     /dev/nvidia* and the GPU stays unallocatable.
+kubectl -n kube-system patch daemonset nvidia-device-plugin-daemonset \
+  --type=json \
+  -p '[{"op":"add","path":"/spec/template/spec/runtimeClassName","value":"nvidia"}]'
+
+# 4d. Verify. Expect "1" (or however many GPUs the instance has).
+kubectl get node -o jsonpath='{.items[0].status.allocatable.nvidia\.com/gpu}'
+echo
+```
+
+## 5. Install BuildKit and build the controller image
+
+`formica-controller` and the evaporation CronJobs reference
+`image: formica:latest`. The image is not published; we build it
+directly into k3s's containerd image store with BuildKit.
+
+```bash
+BK_VERSION=v0.18.1
+curl -fsSL "https://github.com/moby/buildkit/releases/download/${BK_VERSION}/buildkit-${BK_VERSION}.linux-amd64.tar.gz" \
+  | sudo tar -C /usr/local -xzf -
+
+# Long-running daemon; running it under nohup is fine for a dev box.
+sudo nohup buildkitd \
+  --oci-worker=false \
+  --containerd-worker=true \
+  --containerd-worker-addr=/run/k3s/containerd/containerd.sock \
+  --containerd-worker-namespace=k8s.io \
+  >/var/log/buildkitd.log 2>&1 &
+
+# Build. ~30s on a g5.xlarge (pure Python deps).
+cd ~/formica
+sudo buildctl build \
+  --frontend dockerfile.v0 \
+  --local context=. \
+  --local dockerfile=. \
+  --output type=image,name=docker.io/library/formica:latest
+
+sudo k3s ctr -n k8s.io images ls -q | grep formica
+```
+
+## 6. Deploy Formica
+
+```bash
+kubectl apply -k deploy/k8s/overlays/dev
+
+# vLLM pulls vllm/vllm-openai:latest (~10 GB). First pull is slow.
+kubectl -n formica rollout status deploy/vllm --timeout=20m
+```
+
+You should see pods settle into this steady state:
+
+```
+NAME                                  READY   STATUS    RESTARTS   AGE
+aws-for-fluent-bit-xxxxx              1/1     Running   0          2m
+formica-controller-xxxxxxxxxx-xxxxx   1/1     Running   0          1m
+neo4j-0                               1/1     Running   0          2m
+otel-collector-xxxxxxxxxx-xxxxx       1/1     Running   0          1m
+vllm-xxxxxxxxxx-xxxxx                 1/1     Running   0          8m
+```
+
+Agent pods (`scout-*`, `forager-*`, `validator-*`) come and go as the
+controller allocates roles. That is correct: Formica treats agents as
+ephemeral Jobs, not long-lived Deployments.
+
+## 7. Run a solve
+
+```bash
+cd ~/formica
+pip3 install -e ".[dev]"
+
+kubectl -n formica port-forward svc/neo4j 7687:7687 &
+kubectl -n formica port-forward svc/vllm  8080:8080 &
+
+export FORMICA_NEO4J_URI=bolt://localhost:7687
+export FORMICA_MODEL_BASE_URL=http://localhost:8080/v1
+
+formica solve "Prove sqrt(2) is irrational" --budget 1 --timeout 600
+```
+
+You should see validated Evidence stream as Validator pods emit it.
+
+## Troubleshooting
+
+**Node goes `NotReady` with disk pressure.**
+The 100 GB root fills up fast when you have Docker + k3s containerd
+both hoarding images. If you came from the k3d path and still have
+`/var/lib/docker`, reclaim it:
+
+```bash
+sudo systemctl stop docker docker.socket
+sudo dnf remove -y docker docker-ce docker-ce-cli containerd.io
+sudo rm -rf /var/lib/docker
+```
+
+On the prebaked AMI the taint clears automatically once free space
+crosses the kubelet eviction threshold.
+
+**`neo4j-0` CrashLoopBackOff with `Unrecognized setting. No declared setting with name: PORT.7687.TCP.PORT`.**
+Kubernetes auto-injects `*_PORT_*` env vars for every Service in the
+namespace, and neo4j's strict config validator rejects them. The base
+manifest already sets `enableServiceLinks: false`; if you edited it
+check that line is present.
+
+**`otel-collector` crashes with `cannot start pipelines: unknown marshaler "otlp_parquet"`.**
+You are running the production (`awss3` + `otlp_parquet`) exporter on a
+collector build that does not include the parquet marshaler. The dev
+overlay in `deploy/k8s/overlays/dev/` patches the ConfigMap to use the
+`debug` exporter instead; make sure you applied the overlay and not
+the bare base.
+
+**vLLM is stuck in `ContainerCreating` for 10+ minutes.**
+Check the pull: `kubectl describe -n formica pod -l app.kubernetes.io/component=vllm`.
+The image is ~10 GB; on a fresh instance with a cold image layer cache
+this can realistically take 5–8 minutes.
+
+**I get `ErrImagePull` for `formica:latest`.**
+The image is not published to Docker Hub. You must build it locally per
+step 5. If buildkitd is not running or pointed at the wrong containerd
+socket, the build succeeds but the image never lands in k3s's store.
+Check `sudo k3s ctr -n k8s.io images ls -q | grep formica`.
+
+## Teardown
+
+```bash
+sudo /usr/local/bin/k3s-uninstall.sh
+```
+
+Then terminate the EC2 instance.

--- a/docs/launch-on-aws.md
+++ b/docs/launch-on-aws.md
@@ -1,8 +1,8 @@
 # Launch Formica on a single EC2 GPU box
 
-This is the exact recipe that is known to bring up a working Formica
-cluster on AWS from scratch. It uses the prebaked open-weight AMI from
-the [rome](https://github.com/abacus2000/rome) project, which ships with
+This is the exact recipe that brings up a working Formica cluster on AWS
+from scratch. It uses the prebaked open-weight AMI from the
+[rome](https://github.com/abacus2000/rome) project, which ships with
 CUDA 13, NVIDIA drivers, `nvidia-container-toolkit`, `nerdctl`, and the
 Mistral-7B-Instruct-v0.2-AWQ weights already staged at
 `/opt/models/mistral-awq`.
@@ -12,120 +12,78 @@ If you are on a different AMI, first install drivers and
 [NVIDIA docs](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
 and stage weights yourself. Everything else below is identical.
 
-## 1. Launch the instance
-
-| Setting             | Value                                             |
-| ------------------- | ------------------------------------------------- |
-| Instance type       | `g5.xlarge` (A10G, 24 GB GPU memory, 4 vCPU, 16 GB RAM) |
-| AMI                 | `ami-079c82d610e02e480` (shared from rome)        |
-| Root volume         | 100 GB gp3 (you will regret anything smaller)     |
-| IAM instance profile| role with `AmazonSSMManagedInstanceCore` attached |
-| Security group      | egress any (pulls from Docker Hub, nvcr.io, GitHub) |
-
-You do not need to open inbound ports. All access is via SSM Session
-Manager or `kubectl port-forward` tunneled over SSH / SSM.
-
-## 2. Connect
+## TL;DR
 
 ```bash
 aws ssm start-session --target i-XXXXXXXXXXXXXXXXX --region us-east-1
 sudo su - ec2-user
+git clone https://github.com/abacus2000/formica.git ~/formica
+cd ~/formica
+bash scripts/launch-single-box.sh
 ```
 
-Clone the repo:
+The script takes ~10 minutes on a fresh instance (most of that is
+pulling the 10 GB vLLM image). It is idempotent; if it fails partway,
+re-run it.
+
+## 1. Launch the instance
+
+| Setting             | Value                                                   |
+| ------------------- | ------------------------------------------------------- |
+| Instance type       | `g5.xlarge` (A10G, 24 GB GPU memory, 4 vCPU, 16 GB RAM) |
+| AMI                 | `ami-079c82d610e02e480` (shared from rome)              |
+| Root volume         | **200 GB gp3** (non-negotiable, see below)              |
+| IAM instance profile| role with `AmazonSSMManagedInstanceCore` attached       |
+| Security group      | egress any (pulls from Docker Hub, nvcr.io, GitHub)     |
+
+**Why 200 GB.** k3s's containerd store unpacks the `vllm/vllm-openai`
+image to ~30 GB by itself. Add the formica build cache, kubelet
+ephemeral storage, the OS, and logs, and anything under 150 GB triggers
+kubelet DiskPressure eviction during the first pull. 100 GB does not
+work. The launcher script refuses to continue with less than 120 GB
+free.
+
+You do not need to open inbound ports. All access is via SSM Session
+Manager or `kubectl port-forward` tunneled over SSM.
+
+## 2. Connect and clone
 
 ```bash
+aws ssm start-session --target i-XXXXXXXXXXXXXXXXX --region us-east-1
+sudo su - ec2-user
+
 git clone https://github.com/abacus2000/formica.git ~/formica
 cd ~/formica
 ```
 
-## 3. Install k3s
+## 3. Run the launcher
 
 ```bash
-curl -sfL https://get.k3s.io | \
-  INSTALL_K3S_EXEC="--disable=traefik --write-kubeconfig-mode=644" sh -
-
-# Give kubectl access to the non-root user.
-mkdir -p ~/.kube
-sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-sudo chown $(id -u):$(id -g) ~/.kube/config
-
-kubectl wait --for=condition=Ready node --all --timeout=120s
+bash scripts/launch-single-box.sh
 ```
 
-Known gotcha: do NOT drop a `config.toml.tmpl` under
-`/var/lib/rancher/k3s/agent/etc/containerd/`. k3s v1.34+ auto-detects
-`nvidia-container-runtime` in `$PATH` and registers it. Adding your own
-template causes containerd to fail with
-`toml: table nvidia already exists` and the node never becomes Ready.
+What it does, in order:
 
-## 4. Expose the GPU to pods
+1. Sanity-checks the GPU and root disk.
+2. Installs k3s v1.34 with Traefik disabled and a readable kubeconfig,
+   then wires `~/.kube/config` for `ec2-user`.
+3. Registers the `nvidia` RuntimeClass, installs the NVIDIA device
+   plugin v0.17.0, and pins the plugin daemonset to the nvidia runtime
+   so it can see `/dev/nvidia*`.
+4. Installs BuildKit v0.18.1 and builds `formica:latest` directly into
+   k3s's containerd image store (no registry push, no Docker).
+5. Applies `deploy/k8s/overlays/dev`, which includes the dev
+   otel-collector ConfigMap (debug exporter, not the production
+   parquet exporter).
+6. Waits for Neo4j, controller, otel, and vLLM to roll out.
+7. Installs the `formica` CLI, port-forwards Neo4j and vLLM to
+   localhost, and runs a `formica solve` smoke test.
 
-```bash
-# 4a. Register the RuntimeClass.
-cat <<'YAML' | kubectl apply -f -
-apiVersion: node.k8s.io/v1
-kind: RuntimeClass
-metadata:
-  name: nvidia
-handler: nvidia
-YAML
+Set `SKIP_SMOKE=1` to stop after step 6. Other knobs
+(`K3S_VERSION`, `BUILDKIT_VERSION`, `DEVICE_PLUGIN_VER`) are documented
+at the top of the script.
 
-# 4b. Install the NVIDIA device plugin.
-kubectl apply -f \
-  https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml
-
-# 4c. Pin the plugin to the nvidia runtime. Without this it cannot see
-#     /dev/nvidia* and the GPU stays unallocatable.
-kubectl -n kube-system patch daemonset nvidia-device-plugin-daemonset \
-  --type=json \
-  -p '[{"op":"add","path":"/spec/template/spec/runtimeClassName","value":"nvidia"}]'
-
-# 4d. Verify. Expect "1" (or however many GPUs the instance has).
-kubectl get node -o jsonpath='{.items[0].status.allocatable.nvidia\.com/gpu}'
-echo
-```
-
-## 5. Install BuildKit and build the controller image
-
-`formica-controller` and the evaporation CronJobs reference
-`image: formica:latest`. The image is not published; we build it
-directly into k3s's containerd image store with BuildKit.
-
-```bash
-BK_VERSION=v0.18.1
-curl -fsSL "https://github.com/moby/buildkit/releases/download/${BK_VERSION}/buildkit-${BK_VERSION}.linux-amd64.tar.gz" \
-  | sudo tar -C /usr/local -xzf -
-
-# Long-running daemon; running it under nohup is fine for a dev box.
-sudo nohup buildkitd \
-  --oci-worker=false \
-  --containerd-worker=true \
-  --containerd-worker-addr=/run/k3s/containerd/containerd.sock \
-  --containerd-worker-namespace=k8s.io \
-  >/var/log/buildkitd.log 2>&1 &
-
-# Build. ~30s on a g5.xlarge (pure Python deps).
-cd ~/formica
-sudo buildctl build \
-  --frontend dockerfile.v0 \
-  --local context=. \
-  --local dockerfile=. \
-  --output type=image,name=docker.io/library/formica:latest
-
-sudo k3s ctr -n k8s.io images ls -q | grep formica
-```
-
-## 6. Deploy Formica
-
-```bash
-kubectl apply -k deploy/k8s/overlays/dev
-
-# vLLM pulls vllm/vllm-openai:latest (~10 GB). First pull is slow.
-kubectl -n formica rollout status deploy/vllm --timeout=20m
-```
-
-You should see pods settle into this steady state:
+## Expected steady state
 
 ```
 NAME                                  READY   STATUS    RESTARTS   AGE
@@ -140,11 +98,106 @@ Agent pods (`scout-*`, `forager-*`, `validator-*`) come and go as the
 controller allocates roles. That is correct: Formica treats agents as
 ephemeral Jobs, not long-lived Deployments.
 
-## 7. Run a solve
+## Running more solves
+
+After the script finishes, the CLI and port-forwards are already set
+up in the shell that ran it:
 
 ```bash
+formica solve "Prove there are infinitely many primes" --budget 1 --timeout 600
+```
+
+In a new shell, re-export the env vars and re-open the port-forwards:
+
+```bash
+export KUBECONFIG=$HOME/.kube/config
+export FORMICA_NEO4J_URI=bolt://localhost:7687
+export FORMICA_MODEL_BASE_URL=http://localhost:8080/v1
+kubectl -n formica port-forward svc/neo4j 7687:7687 &
+kubectl -n formica port-forward svc/vllm  8080:8080 &
+```
+
+## What the script is doing, manually
+
+If you need to diagnose a failure or integrate this into another tool,
+here are the same operations broken out step by step.
+
+### k3s
+
+```bash
+curl -sfL https://get.k3s.io | \
+  INSTALL_K3S_EXEC="--disable=traefik --write-kubeconfig-mode=644" sh -
+
+mkdir -p ~/.kube
+sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+sudo chown $(id -u):$(id -g) ~/.kube/config
+
+kubectl wait --for=condition=Ready node --all --timeout=120s
+```
+
+**Gotcha.** Do not drop a `config.toml.tmpl` under
+`/var/lib/rancher/k3s/agent/etc/containerd/`. k3s v1.34+ auto-detects
+`nvidia-container-runtime` in `$PATH` and registers it. A custom
+template causes containerd to fail with
+`toml: table nvidia already exists` and the node never becomes Ready.
+
+### GPU
+
+```bash
+# RuntimeClass
+cat <<'YAML' | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: nvidia
+handler: nvidia
+YAML
+
+# Device plugin
+kubectl apply -f \
+  https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml
+
+# Pin to nvidia runtime so the plugin can see /dev/nvidia*
+kubectl -n kube-system patch daemonset nvidia-device-plugin-daemonset \
+  --type=json \
+  -p '[{"op":"add","path":"/spec/template/spec/runtimeClassName","value":"nvidia"}]'
+
+# Verify: expect "1"
+kubectl get node -o jsonpath='{.items[0].status.allocatable.nvidia\.com/gpu}'
+```
+
+### Image
+
+```bash
+BK_VERSION=v0.18.1
+curl -fsSL "https://github.com/moby/buildkit/releases/download/${BK_VERSION}/buildkit-${BK_VERSION}.linux-amd64.tar.gz" \
+  | sudo tar -C /usr/local -xzf -
+
+sudo nohup buildkitd \
+  --oci-worker=false \
+  --containerd-worker=true \
+  --containerd-worker-addr=/run/k3s/containerd/containerd.sock \
+  --containerd-worker-namespace=k8s.io \
+  >/var/log/buildkitd.log 2>&1 &
+
 cd ~/formica
-pip3 install -e ".[dev]"
+sudo buildctl build \
+  --frontend dockerfile.v0 \
+  --local context=. \
+  --local dockerfile=. \
+  --output type=image,name=docker.io/library/formica:latest
+
+sudo k3s ctr -n k8s.io images ls -q | grep formica
+```
+
+### Deploy and solve
+
+```bash
+kubectl apply -k deploy/k8s/overlays/dev
+kubectl -n formica rollout status deploy/vllm --timeout=20m
+
+pip3 install --user -e ".[dev]"
+export PATH=$HOME/.local/bin:$PATH
 
 kubectl -n formica port-forward svc/neo4j 7687:7687 &
 kubectl -n formica port-forward svc/vllm  8080:8080 &
@@ -155,47 +208,40 @@ export FORMICA_MODEL_BASE_URL=http://localhost:8080/v1
 formica solve "Prove sqrt(2) is irrational" --budget 1 --timeout 600
 ```
 
-You should see validated Evidence stream as Validator pods emit it.
-
 ## Troubleshooting
 
-**Node goes `NotReady` with disk pressure.**
-The 100 GB root fills up fast when you have Docker + k3s containerd
-both hoarding images. If you came from the k3d path and still have
-`/var/lib/docker`, reclaim it:
-
-```bash
-sudo systemctl stop docker docker.socket
-sudo dnf remove -y docker docker-ce docker-ce-cli containerd.io
-sudo rm -rf /var/lib/docker
-```
-
-On the prebaked AMI the taint clears automatically once free space
-crosses the kubelet eviction threshold.
+**Disk pressure during the first pull.**
+Usually means the root volume is under 150 GB. The script preflights
+for 120 GB free; if you started with 100 GB and DiskPressure fires
+anyway, the cleanest fix is to terminate, relaunch with 200 GB, and
+re-run.
 
 **`neo4j-0` CrashLoopBackOff with `Unrecognized setting. No declared setting with name: PORT.7687.TCP.PORT`.**
 Kubernetes auto-injects `*_PORT_*` env vars for every Service in the
-namespace, and neo4j's strict config validator rejects them. The base
-manifest already sets `enableServiceLinks: false`; if you edited it
-check that line is present.
+namespace, and Neo4j's strict config validator rejects them. The base
+manifest sets `enableServiceLinks: false`; if you edited it, confirm
+that line is present.
 
 **`otel-collector` crashes with `cannot start pipelines: unknown marshaler "otlp_parquet"`.**
-You are running the production (`awss3` + `otlp_parquet`) exporter on a
-collector build that does not include the parquet marshaler. The dev
-overlay in `deploy/k8s/overlays/dev/` patches the ConfigMap to use the
-`debug` exporter instead; make sure you applied the overlay and not
-the bare base.
+You applied the base instead of the dev overlay. The production
+manifest uses an `awss3` exporter with the `otlp_parquet` marshaler,
+which is not compiled into the stock contrib image. The dev overlay
+patches the ConfigMap to use the `debug` exporter; run
+`kubectl apply -k deploy/k8s/overlays/dev` rather than
+`kubectl apply -k deploy/k8s/base`.
 
-**vLLM is stuck in `ContainerCreating` for 10+ minutes.**
+**vLLM stuck in `ContainerCreating` for 10+ minutes.**
 Check the pull: `kubectl describe -n formica pod -l app.kubernetes.io/component=vllm`.
-The image is ~10 GB; on a fresh instance with a cold image layer cache
-this can realistically take 5–8 minutes.
+The image is ~10 GB; on a fresh instance with a cold cache, 5-8 minutes
+is normal. Longer than that usually means network egress is blocked
+or the kubelet hit DiskPressure and evicted the sandbox.
 
-**I get `ErrImagePull` for `formica:latest`.**
-The image is not published to Docker Hub. You must build it locally per
-step 5. If buildkitd is not running or pointed at the wrong containerd
-socket, the build succeeds but the image never lands in k3s's store.
-Check `sudo k3s ctr -n k8s.io images ls -q | grep formica`.
+**`ErrImagePull` for `formica:latest`.**
+The image is not published to Docker Hub. The launcher builds it via
+BuildKit in step 4. If buildkitd died or was pointed at the wrong
+containerd socket, the build succeeds but the image never lands in
+k3s's store. Verify with
+`sudo k3s ctr -n k8s.io images ls -q | grep formica`.
 
 ## Teardown
 

--- a/docs/single-box.md
+++ b/docs/single-box.md
@@ -1,56 +1,115 @@
-# Single-box Formica (k3d on a GPU EC2 instance)
+# Single-box Formica (bare k3s on a GPU host)
 
 Formica runs the same Kubernetes manifests whether you have one node or
-fifty. For single-box development, we use [k3d](https://k3d.io/) - a
-lightweight k3s cluster that runs inside Docker on a single host - so
-you exercise the real controller / Job / Service / RBAC path on your
-laptop or on a single GPU EC2 box.
+fifty. For single-box development, we run [k3s](https://k3s.io/) directly
+on the host as a systemd service, so you exercise the real controller /
+Job / Service / RBAC path on your laptop or on a single GPU EC2 box.
 
-> This is the **first-class** single-box workflow. There is no separate
-> Docker Compose stack and no in-process `--local` mode.
+k3s is bundled with containerd. There is no Docker layer, no k3d wrapper,
+and no in-process `--local` mode. One node is first-class.
 
 ## What you need
 
 Any Linux box that has:
 
-1. Docker (for k3d).
-2. An NVIDIA GPU + drivers + `nvidia-container-toolkit` (if you want
-   vLLM on-cluster; otherwise set `FORMICA_MODEL_PROVIDER=bedrock` and
-   skip the GPU bits).
-3. `kubectl`, `kustomize`, and `k3d` on your PATH.
-4. Mistral-7B-AWQ weights at `/opt/models/mistral-awq` on the host (the
-   k3d cluster mounts this into the vLLM pod; see below).
+1. An NVIDIA GPU with drivers installed and `/usr/bin/nvidia-container-runtime`
+   on the PATH (install `nvidia-container-toolkit`). If you do not have a
+   GPU, set `FORMICA_MODEL_PROVIDER=bedrock` and skip the GPU bits.
+2. `curl`, `systemd`, and root access to install k3s.
+3. Mistral-7B-AWQ weights at `/opt/models/mistral-awq` on the host. The
+   vLLM pod mounts this via a `hostPath` volume.
 
-The canonical environment is a `g4dn.xlarge` launched from the prebaked
-open-weight AMI (`ami-079c82d610e02e480`) shared with the
-[rome](https://github.com/abacus2000/rome) project. That AMI already
-has everything in items 1–4.
+The canonical environment is a `g5.xlarge` (or `g4dn.xlarge`) launched
+from the prebaked open-weight AMI (`ami-079c82d610e02e480`) shared with
+the [rome](https://github.com/abacus2000/rome) project. That AMI already
+has everything in items 1–3.
+
+For a step-by-step EC2 walkthrough, see [launch-on-aws.md](./launch-on-aws.md).
 
 ## Bring up the cluster
 
 ```bash
-# 1. Create a GPU-enabled k3d cluster.
-#    --gpus all  forwards the host's GPUs into the k3s node container.
-#    --volume    bind-mounts the weights directory so the vllm pod can
-#                hostPath-mount /opt/models.
-k3d cluster create formica \
-  --gpus all \
-  --volume "/opt/models:/opt/models@all" \
-  --port "8080:8080@loadbalancer" \
-  --port "7474:7474@loadbalancer" \
-  --port "7687:7687@loadbalancer"
+# 1. Install k3s as a systemd service. k3s v1.34+ auto-detects
+#    nvidia-container-runtime on the host and registers it with containerd,
+#    so you do NOT need a custom /var/lib/rancher/k3s/agent/etc/containerd
+#    config template. Adding one will cause a 'toml: table nvidia already
+#    exists' error on startup.
+curl -sfL https://get.k3s.io | \
+  INSTALL_K3S_EXEC="--disable=traefik --write-kubeconfig-mode=644" sh -
 
-# 2. Install the NVIDIA device plugin inside the cluster so pods can
-#    request nvidia.com/gpu. (Skip if you use the NVIDIA GPU Operator.)
-kubectl apply -f \
-  https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.15.0/deployments/static/nvidia-device-plugin.yml
+# 2. Wait for the node to go Ready.
+sudo k3s kubectl wait --for=condition=Ready node --all --timeout=120s
 
-# 3. Deploy Formica.
-kubectl apply -k deploy/k8s/overlays/dev
+# 3. Register the nvidia RuntimeClass so pods can opt into the nvidia runtime.
+cat <<'YAML' | sudo k3s kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: nvidia
+handler: nvidia
+YAML
 
-# 4. Wait for vLLM to come up (60–120s on the prebaked AMI).
-kubectl -n formica rollout status deploy/vllm --timeout=15m
+# 4. Install the NVIDIA device plugin so pods can request nvidia.com/gpu.
+#    The daemonset MUST run under runtimeClassName: nvidia; otherwise it
+#    cannot see /dev/nvidia* and will never mark the GPU allocatable.
+sudo k3s kubectl apply -f \
+  https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml
+
+sudo k3s kubectl -n kube-system patch daemonset nvidia-device-plugin-daemonset \
+  --type=json \
+  -p '[{"op":"add","path":"/spec/template/spec/runtimeClassName","value":"nvidia"}]'
+
+# 5. Confirm the GPU is allocatable. This should print "1".
+sudo k3s kubectl get node -o jsonpath='{.items[0].status.allocatable.nvidia\.com/gpu}'
+echo
+
+# 6. Deploy Formica.
+sudo k3s kubectl apply -k deploy/k8s/overlays/dev
+
+# 7. Wait for vLLM to come up. The vllm/vllm-openai:latest image is ~10GB;
+#    first pull is 3-5 minutes on a typical EC2 link. Model load is
+#    another 60-120s with pre-baked AWQ weights.
+sudo k3s kubectl -n formica rollout status deploy/vllm --timeout=20m
 ```
+
+### Building the controller image
+
+The `formica-controller` Deployment and the two `formica-*-evaporation`
+CronJobs reference `image: formica:latest` with
+`imagePullPolicy: IfNotPresent`. The image is not published to any
+registry; you build it locally and the tag lives in k3s's containerd
+image store.
+
+Install [BuildKit](https://github.com/moby/buildkit) and build against
+the k3s containerd socket so the resulting image is immediately visible
+to kubelet:
+
+```bash
+BK_VERSION=v0.18.1
+curl -fsSL "https://github.com/moby/buildkit/releases/download/${BK_VERSION}/buildkit-${BK_VERSION}.linux-amd64.tar.gz" \
+  | sudo tar -C /usr/local -xzf -
+
+# Run buildkitd with the containerd worker pointed at k3s's socket.
+sudo nohup buildkitd \
+  --oci-worker=false \
+  --containerd-worker=true \
+  --containerd-worker-addr=/run/k3s/containerd/containerd.sock \
+  --containerd-worker-namespace=k8s.io \
+  >/var/log/buildkitd.log 2>&1 &
+
+# Build. The image lands directly in the k3s image store.
+cd ~/formica
+sudo buildctl build \
+  --frontend dockerfile.v0 \
+  --local context=. \
+  --local dockerfile=. \
+  --output type=image,name=docker.io/library/formica:latest
+
+# Verify.
+sudo k3s ctr -n k8s.io images ls -q | grep formica
+```
+
+No registry, no push, no Docker daemon.
 
 ## Submit an objective
 
@@ -59,11 +118,11 @@ From outside the cluster (e.g. the EC2 instance's shell):
 ```bash
 pip install -e ".[dev]"
 
-# The CLI is a thin client - it writes to Neo4j and polls. The colony
+# The CLI is a thin client: it writes to Neo4j and polls. The colony
 # lives in the cluster. Port-forward Neo4j and vLLM so local env vars
 # Just Work.
-kubectl -n formica port-forward svc/neo4j 7687:7687 &
-kubectl -n formica port-forward svc/vllm  8080:8080 &
+sudo k3s kubectl -n formica port-forward svc/neo4j 7687:7687 &
+sudo k3s kubectl -n formica port-forward svc/vllm  8080:8080 &
 
 export FORMICA_NEO4J_URI=bolt://localhost:7687
 export FORMICA_MODEL_BASE_URL=http://localhost:8080/v1
@@ -78,29 +137,30 @@ emit it.
 
 ```bash
 # Controller decisions (spawn/retire/phase transitions).
-kubectl -n formica logs -f deploy/formica-controller
+sudo k3s kubectl -n formica logs -f deploy/formica-controller
 
-# Live pod list - scouts, foragers, validators, gc appear and disappear
+# Live pod list: scouts, foragers, validators, gc appear and disappear
 # as the controller reallocates roles.
-watch kubectl -n formica get pods
+watch sudo k3s kubectl -n formica get pods
 
 # Neo4j browser (pheromones, subproblem graph).
-# neo4j / changeme  - override via deploy/k8s/base/neo4j.yaml for prod.
+# neo4j / changeme - override via deploy/k8s/base/neo4j.yaml for prod.
 open http://localhost:7474
 ```
 
 ## Tearing down
 
 ```bash
-k3d cluster delete formica
+sudo /usr/local/bin/k3s-uninstall.sh
 ```
 
-Neo4j's PVC is backed by the k3d node's local storage and is deleted
-with the cluster, so this is a clean reset.
+This stops the service, removes containerd state, and wipes every Pod
+and Volume on the node. Weights under `/opt/models` are preserved (they
+live on the host, not in the cluster).
 
-## From k3d to EKS
+## From bare k3s to EKS
 
-The exact same manifests work on a real multi-node EKS cluster - that's
+The exact same manifests work on a real multi-node EKS cluster; that's
 the whole point. You only need to swap two things:
 
 1. **vLLM weights.** The `vllm.yaml` base manifest uses a `hostPath`

--- a/scripts/launch-single-box.sh
+++ b/scripts/launch-single-box.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+#
+# launch-single-box.sh
+#
+# One-shot bring-up for a Formica single-box deployment on a fresh
+# Amazon Linux 2023 EC2 GPU instance (validated on g5.xlarge with the
+# rome AMI, ami-079c82d610e02e480).
+#
+# Produces a cluster with:
+#   - k3s v1.34 (containerd, no Docker)
+#   - NVIDIA device plugin with RuntimeClass "nvidia"
+#   - BuildKit building formica:latest directly into k3s containerd
+#   - Formica controller, Neo4j, vLLM, and the dev otel collector
+#
+# The script is idempotent: each step checks whether it has already run
+# and skips cleanly. Safe to re-run if interrupted.
+#
+# Run as ec2-user (NOT root, NOT via sudo). The script will invoke
+# sudo itself where needed.
+#
+# Usage:
+#   cd ~/formica
+#   bash scripts/launch-single-box.sh
+#
+# Environment knobs:
+#   FORMICA_REPO_DIR  Path to the cloned repo (default: $HOME/formica)
+#   K3S_VERSION       Pin a specific k3s channel (default: v1.34 via get.k3s.io)
+#   BUILDKIT_VERSION  BuildKit release (default: v0.18.1)
+#   DEVICE_PLUGIN_VER NVIDIA device plugin (default: v0.17.0)
+#   SKIP_SMOKE        If set to 1, skip the final formica solve smoke test.
+
+set -euo pipefail
+
+REPO_DIR="${FORMICA_REPO_DIR:-$HOME/formica}"
+BUILDKIT_VERSION="${BUILDKIT_VERSION:-v0.18.1}"
+DEVICE_PLUGIN_VER="${DEVICE_PLUGIN_VER:-v0.17.0}"
+SKIP_SMOKE="${SKIP_SMOKE:-0}"
+
+STEP=0
+step() {
+  STEP=$((STEP + 1))
+  echo
+  echo "========================================"
+  echo "[step $STEP] $*"
+  echo "========================================"
+}
+note() { echo "    $*"; }
+
+if [[ $EUID -eq 0 ]]; then
+  echo "Do not run this as root. Run as ec2-user; sudo is invoked internally."
+  exit 1
+fi
+
+if [[ ! -d "$REPO_DIR" ]]; then
+  echo "Repo not found at $REPO_DIR. Clone it first:"
+  echo "  git clone https://github.com/abacus2000/formica.git $REPO_DIR"
+  exit 1
+fi
+
+cd "$REPO_DIR"
+
+# ---------------------------------------------------------------
+step "Preflight: GPU, disk, and tools"
+# ---------------------------------------------------------------
+if ! command -v nvidia-smi >/dev/null; then
+  echo "nvidia-smi not found. This script assumes the rome AMI (CUDA + driver preinstalled)."
+  echo "On a vanilla AMI, install driver + nvidia-container-toolkit first."
+  exit 1
+fi
+nvidia-smi -L
+
+ROOT_FREE_GB=$(df -BG / | awk 'NR==2 {gsub("G",""); print $4}')
+note "Free space on /: ${ROOT_FREE_GB} GB"
+if [[ "$ROOT_FREE_GB" -lt 120 ]]; then
+  echo
+  echo "ERROR: less than 120 GB free on /. This run will fill the disk."
+  echo "       Launch the instance with a 200 GB gp3 root volume."
+  echo "       (k3s containerd needs ~40 GB for the vLLM image alone,"
+  echo "        plus the formica:latest build cache and kubelet ephemeral.)"
+  exit 1
+fi
+
+# ---------------------------------------------------------------
+step "Install k3s (no Traefik, readable kubeconfig)"
+# ---------------------------------------------------------------
+if systemctl is-active --quiet k3s; then
+  note "k3s already active, skipping install"
+else
+  curl -sfL https://get.k3s.io | \
+    INSTALL_K3S_EXEC="--disable=traefik --write-kubeconfig-mode=644" sh -
+fi
+
+# Wire kubectl for ec2-user
+mkdir -p "$HOME/.kube"
+sudo cp /etc/rancher/k3s/k3s.yaml "$HOME/.kube/config"
+sudo chown "$(id -u):$(id -g)" "$HOME/.kube/config"
+export KUBECONFIG="$HOME/.kube/config"
+
+kubectl wait --for=condition=Ready node --all --timeout=180s
+note "k3s up. Node:"
+kubectl get nodes
+
+# ---------------------------------------------------------------
+step "Expose GPU to pods (RuntimeClass + device plugin)"
+# ---------------------------------------------------------------
+cat <<'YAML' | kubectl apply -f -
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: nvidia
+handler: nvidia
+YAML
+
+kubectl apply -f \
+  "https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/${DEVICE_PLUGIN_VER}/deployments/static/nvidia-device-plugin.yml"
+
+# Pin the plugin daemonset to the nvidia runtime so it can see /dev/nvidia*.
+# This patch is a no-op on re-apply.
+CURRENT_RC=$(kubectl -n kube-system get ds nvidia-device-plugin-daemonset \
+  -o jsonpath='{.spec.template.spec.runtimeClassName}' 2>/dev/null || echo "")
+if [[ "$CURRENT_RC" != "nvidia" ]]; then
+  kubectl -n kube-system patch daemonset nvidia-device-plugin-daemonset \
+    --type=json \
+    -p '[{"op":"add","path":"/spec/template/spec/runtimeClassName","value":"nvidia"}]'
+fi
+
+note "Waiting for device plugin to advertise nvidia.com/gpu..."
+for i in {1..30}; do
+  GPU=$(kubectl get node -o jsonpath='{.items[0].status.allocatable.nvidia\.com/gpu}' 2>/dev/null || echo "")
+  if [[ -n "$GPU" && "$GPU" != "0" ]]; then
+    note "Allocatable GPUs: $GPU"
+    break
+  fi
+  sleep 4
+done
+[[ -n "${GPU:-}" && "$GPU" != "0" ]] || { echo "GPU never became allocatable"; exit 1; }
+
+# ---------------------------------------------------------------
+step "Install BuildKit and build formica:latest into k3s containerd"
+# ---------------------------------------------------------------
+if ! command -v buildctl >/dev/null; then
+  curl -fsSL "https://github.com/moby/buildkit/releases/download/${BUILDKIT_VERSION}/buildkit-${BUILDKIT_VERSION}.linux-amd64.tar.gz" \
+    | sudo tar -C /usr/local -xzf -
+fi
+
+if ! pgrep -x buildkitd >/dev/null; then
+  sudo nohup /usr/local/bin/buildkitd \
+    --oci-worker=false \
+    --containerd-worker=true \
+    --containerd-worker-addr=/run/k3s/containerd/containerd.sock \
+    --containerd-worker-namespace=k8s.io \
+    >/var/log/buildkitd.log 2>&1 &
+  sleep 4
+fi
+
+note "Building formica:latest (this pulls the base image on first run)..."
+sudo /usr/local/bin/buildctl build \
+  --frontend dockerfile.v0 \
+  --local context=. \
+  --local dockerfile=. \
+  --output type=image,name=docker.io/library/formica:latest
+
+sudo k3s ctr -n k8s.io images ls -q | grep -q '^docker.io/library/formica:latest$' \
+  || { echo "Build succeeded but image not in k3s containerd store"; exit 1; }
+note "formica:latest is in k3s containerd store."
+
+# ---------------------------------------------------------------
+step "Deploy Formica (dev overlay)"
+# ---------------------------------------------------------------
+kubectl apply -k deploy/k8s/overlays/dev
+
+note "Waiting for the core deployments. vLLM pulls ~10 GB on a fresh box,"
+note "so it can legitimately take 5-10 minutes."
+
+# Neo4j is a StatefulSet and comes up in ~1 minute.
+kubectl -n formica rollout status statefulset/neo4j --timeout=5m
+
+# Controller typically Ready in under a minute once neo4j is.
+kubectl -n formica rollout status deploy/formica-controller --timeout=5m
+
+# Otel collector is immediate.
+kubectl -n formica rollout status deploy/otel-collector --timeout=2m
+
+# vLLM is the long pole.
+kubectl -n formica rollout status deploy/vllm --timeout=20m
+
+note "Pod status:"
+kubectl -n formica get pods -o wide
+
+# ---------------------------------------------------------------
+step "Smoke test: formica solve"
+# ---------------------------------------------------------------
+if [[ "$SKIP_SMOKE" == "1" ]]; then
+  note "SKIP_SMOKE=1, skipping."
+  exit 0
+fi
+
+# Install the CLI into the user's site-packages.
+if ! command -v formica >/dev/null; then
+  note "Installing formica CLI (pip install -e)..."
+  python3 -m pip install --user -e ".[dev]"
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# Port-forwards. Kill any old ones first.
+pkill -f "kubectl.*port-forward.*neo4j"  2>/dev/null || true
+pkill -f "kubectl.*port-forward.*vllm"   2>/dev/null || true
+sleep 1
+kubectl -n formica port-forward svc/neo4j 7687:7687 >/tmp/pf-neo4j.log 2>&1 &
+kubectl -n formica port-forward svc/vllm  8080:8080 >/tmp/pf-vllm.log  2>&1 &
+sleep 3
+
+export FORMICA_NEO4J_URI="bolt://localhost:7687"
+export FORMICA_MODEL_BASE_URL="http://localhost:8080/v1"
+
+note "Running: formica solve \"Prove sqrt(2) is irrational\" --budget 1 --timeout 600"
+formica solve "Prove sqrt(2) is irrational" --budget 1 --timeout 600
+
+echo
+echo "==================================================="
+echo "Formica is up. Pod state:"
+echo "==================================================="
+kubectl -n formica get pods


### PR DESCRIPTION
## Summary

Switches the single-box path from k3d to bare k3s, and documents a reproducible EC2 launch recipe. This unblocks GPU workloads on one-machine deployments (k3d on Alpine was missing the NVIDIA container toolkit) and dramatically reduces moving parts.

## Why

Per the project principle that one machine is first class, we want the single-box path to be real k8s, not a nested container runtime. Bare k3s gives us:
- Real GPU support (RuntimeClass nvidia + device plugin, no nested toolkit)
- No Docker on the host (reclaimed 22 GB on g5.xlarge)
- BuildKit builds directly into the k3s containerd store, no registry needed

## Changes

- deploy/k8s/base/vllm.yaml: add runtimeClassName: nvidia
- deploy/k8s/base/neo4j.yaml: enableServiceLinks: false (k8s service env vars collided with Neo4j's NEO4J_* config)
- deploy/k8s/overlays/dev/kustomization.yaml: patch otel-collector ConfigMap to use the debug exporter in dev (stock contrib image lacks the parquet marshaler used in prod)
- docs/launch-on-aws.md: NEW 207-line step-by-step recipe with troubleshooting
- docs/single-box.md: rewritten around bare k3s; k3d references removed
- README.md: Launch section updated; Docker and k3d dropped from prereqs

## Verified

On a fresh g5.xlarge (Amazon Linux 2023, A10G):
- k3s v1.34.6 comes up with nvidia.com/gpu: 1 allocatable
- BuildKit produces formica:latest into the k3s containerd store
- Controller reaches Neo4j, schema writes succeed, agents spawn
- vLLM pod picks up the GPU via RuntimeClass

End-to-end solve smoke test is pending final confirmation on the live box; will update this PR body once it lands.