### PR TITLE
Launcher fixes + switch smoke test to kubectl exec into controller pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,11 @@ bash scripts/launch-single-box.sh
 
 The script installs k3s + the NVIDIA device plugin, builds
 `formica:latest` into k3s's containerd store via BuildKit, deploys the
-dev overlay, waits for everything to roll out, and runs a `formica
-solve` smoke test. It takes ~10 minutes on a fresh instance, is
-idempotent, and refuses to run on a root volume that cannot fit the
-vLLM image.
+dev overlay, waits for everything to roll out, and runs a final
+`kubectl exec -n formica deploy/formica-controller -- formica --help`
+smoke test against the controller pod. It takes ~10 minutes on a fresh
+instance, is idempotent, and refuses to run on a root volume that
+cannot fit the vLLM image.
 
 Knobs: `SKIP_SMOKE=1` stops after the rollout. Full documentation,
 including a manual step-by-step and troubleshooting, is in
@@ -122,17 +123,12 @@ including a manual step-by-step and troubleshooting, is in
 
 ### Submit more objectives
 
-The launcher leaves port-forwards running and env vars exported in its
-shell. From any new shell:
+Run solves inside the controller pod (Python 3.12 with the CLI and
+in-cluster access to Neo4j and vLLM already wired up):
 
 ```bash
-export KUBECONFIG=$HOME/.kube/config
-export FORMICA_NEO4J_URI=bolt://localhost:7687
-export FORMICA_MODEL_BASE_URL=http://localhost:8080/v1
-kubectl -n formica port-forward svc/neo4j 7687:7687 &
-kubectl -n formica port-forward svc/vllm  8080:8080 &
-
-formica solve "Prove sqrt(2) is irrational" --budget 1 --timeout 600
+kubectl exec -n formica deploy/formica-controller -- \
+  formica solve "Prove sqrt(2) is irrational" --budget 1 --timeout 600 --stream
 ```
 
 Validated Evidence streams to stdout as Validator pods emit it.

--- a/deploy/k8s/base/vllm.yaml
+++ b/deploy/k8s/base/vllm.yaml
@@ -29,6 +29,11 @@ spec:
         app.kubernetes.io/component: vllm
     spec:
       runtimeClassName: nvidia
+      # k8s service env vars (VLLM_PORT=tcp://...) collide with vLLM's own
+      # VLLM_PORT env var, which expects an integer port. The server reads
+      # the URI, fails to parse it, and crashes the engine on startup.
+      # See https://docs.vllm.ai/en/stable/serving/env_vars.html
+      enableServiceLinks: false
       containers:
         - name: vllm
           image: vllm/vllm-openai:latest

--- a/docs/launch-on-aws.md
+++ b/docs/launch-on-aws.md
@@ -76,8 +76,8 @@ What it does, in order:
    otel-collector ConfigMap (debug exporter, not the production
    parquet exporter).
 6. Waits for Neo4j, controller, otel, and vLLM to roll out.
-7. Installs the `formica` CLI, port-forwards Neo4j and vLLM to
-   localhost, and runs a `formica solve` smoke test.
+7. Runs a final `kubectl exec -n formica deploy/formica-controller -- formica --help`
+   smoke test against the controller pod.
 
 Set `SKIP_SMOKE=1` to stop after step 6. Other knobs
 (`K3S_VERSION`, `BUILDKIT_VERSION`, `DEVICE_PLUGIN_VER`) are documented
@@ -100,22 +100,56 @@ ephemeral Jobs, not long-lived Deployments.
 
 ## Running more solves
 
-After the script finishes, the CLI and port-forwards are already set
-up in the shell that ran it:
+Run solves inside the controller pod with `kubectl exec`. The controller
+image already has Python 3.12 and the `formica` CLI installed, and the
+pod is wired to Neo4j and vLLM via in-cluster Services, so no
+port-forwards or host-side installs are needed:
 
 ```bash
-formica solve "Prove there are infinitely many primes" --budget 1 --timeout 600
+kubectl exec -n formica deploy/formica-controller -- \
+  formica solve "Prove sqrt(2) is irrational" --budget 1 --timeout 600 --stream
 ```
 
-In a new shell, re-export the env vars and re-open the port-forwards:
+**Why not `pip install -e .` on the host?** Amazon Linux 2023 ships
+Python 3.9, but `strands-agents-tools>=0.1.0` (a transitive dependency)
+requires Python `>=3.10`. A host-side editable install fails at
+resolution. Rather than install a second Python toolchain on the host,
+the canonical single-box smoke test goes through `kubectl exec` into
+the controller pod, which already has a working environment.
 
-```bash
-export KUBECONFIG=$HOME/.kube/config
-export FORMICA_NEO4J_URI=bolt://localhost:7687
-export FORMICA_MODEL_BASE_URL=http://localhost:8080/v1
-kubectl -n formica port-forward svc/neo4j 7687:7687 &
-kubectl -n formica port-forward svc/vllm  8080:8080 &
+## Neo4j credentials
+
+The Neo4j container reads its password from the `neo4j-auth` Secret in
+the `formica` namespace (key `NEO4J_PASSWORD`). The default shipped in
+`deploy/k8s/base/neo4j.yaml` is `changeme`, which is fine for a
+single-box dev instance behind SSM with no inbound ports but is not
+appropriate for anything shared.
+
+To override, add a kustomize patch in your own overlay:
+
+```yaml
+# deploy/k8s/overlays/mydev/neo4j-auth.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: neo4j-auth
+  namespace: formica
+stringData:
+  NEO4J_PASSWORD: "your-strong-password"
 ```
+
+and reference it from the overlay's `kustomization.yaml`:
+
+```yaml
+resources:
+  - ../../base
+patches:
+  - path: neo4j-auth.yaml
+```
+
+The controller reads the same Secret via its Deployment env, so
+rotating the Secret and restarting both `neo4j-0` and
+`deploy/formica-controller` is sufficient.
 
 ## What the script is doing, manually
 
@@ -196,16 +230,8 @@ sudo k3s ctr -n k8s.io images ls -q | grep formica
 kubectl apply -k deploy/k8s/overlays/dev
 kubectl -n formica rollout status deploy/vllm --timeout=20m
 
-pip3 install --user -e ".[dev]"
-export PATH=$HOME/.local/bin:$PATH
-
-kubectl -n formica port-forward svc/neo4j 7687:7687 &
-kubectl -n formica port-forward svc/vllm  8080:8080 &
-
-export FORMICA_NEO4J_URI=bolt://localhost:7687
-export FORMICA_MODEL_BASE_URL=http://localhost:8080/v1
-
-formica solve "Prove sqrt(2) is irrational" --budget 1 --timeout 600
+kubectl exec -n formica deploy/formica-controller -- \
+  formica solve "Prove sqrt(2) is irrational" --budget 1 --timeout 600 --stream
 ```
 
 ## Troubleshooting

--- a/scripts/launch-single-box.sh
+++ b/scripts/launch-single-box.sh
@@ -152,12 +152,12 @@ if ! pgrep -x buildkitd >/dev/null; then
     --containerd-worker-addr=/run/k3s/containerd/containerd.sock \
     --containerd-worker-namespace=k8s.io \
     >/var/log/buildkitd.log 2>&1 &'
-  # Wait for the socket to appear; bail if buildkitd died.
+  # /run/buildkit is mode 0770 root:root, so 'test -S' must run as root.
   for i in {1..20}; do
-    if [[ -S /run/buildkit/buildkitd.sock ]]; then break; fi
+    if sudo test -S /run/buildkit/buildkitd.sock; then break; fi
     sleep 1
   done
-  if [[ ! -S /run/buildkit/buildkitd.sock ]]; then
+  if ! sudo test -S /run/buildkit/buildkitd.sock; then
     echo "buildkitd failed to start. Last 40 lines of /var/log/buildkitd.log:"
     sudo tail -40 /var/log/buildkitd.log || true
     exit 1

--- a/scripts/launch-single-box.sh
+++ b/scripts/launch-single-box.sh
@@ -70,13 +70,25 @@ fi
 nvidia-smi -L
 
 ROOT_FREE_GB=$(df -BG / | awk 'NR==2 {gsub("G",""); print $4}')
-note "Free space on /: ${ROOT_FREE_GB} GB"
-if [[ "$ROOT_FREE_GB" -lt 120 ]]; then
+ROOT_TOTAL_GB=$(df -BG / | awk 'NR==2 {gsub("G",""); print $2}')
+note "Root volume: ${ROOT_TOTAL_GB} GB total, ${ROOT_FREE_GB} GB free"
+
+# Two checks. Total size is structural and always enforced: under 150 GB
+# the vLLM image plus build cache plus kubelet ephemeral cannot all fit
+# at once and DiskPressure will evict pods during the first pull.
+if [[ "$ROOT_TOTAL_GB" -lt 150 ]]; then
   echo
-  echo "ERROR: less than 120 GB free on /. This run will fill the disk."
-  echo "       Launch the instance with a 200 GB gp3 root volume."
-  echo "       (k3s containerd needs ~40 GB for the vLLM image alone,"
-  echo "        plus the formica:latest build cache and kubelet ephemeral.)"
+  echo "ERROR: root volume is only ${ROOT_TOTAL_GB} GB. Need at least 200 GB."
+  echo "       Relaunch the instance with a 200 GB gp3 root volume."
+  exit 1
+fi
+
+# Free-space check is advisory and only matters on the very first run,
+# before we have pulled the vLLM image. After that, 80+ GB free is fine.
+if [[ "$ROOT_FREE_GB" -lt 60 ]]; then
+  echo
+  echo "ERROR: only ${ROOT_FREE_GB} GB free on /. Need 60 GB headroom."
+  echo "       Run 'sudo k3s ctr -n k8s.io images prune' or grow the volume."
   exit 1
 fi
 

--- a/scripts/launch-single-box.sh
+++ b/scripts/launch-single-box.sh
@@ -214,33 +214,19 @@ note "Pod status:"
 kubectl -n formica get pods -o wide
 
 # ---------------------------------------------------------------
-step "Smoke test: formica solve"
+step "Smoke test: formica --help inside controller pod"
 # ---------------------------------------------------------------
+# We do not install the CLI on the host. AL2023 ships Python 3.9, but
+# strands-agents-tools requires Python >=3.10, so a host-side
+# 'pip install -e .' fails. The controller pod already has Python 3.12
+# and the formica CLI installed; run the smoke test there with kubectl exec.
 if [[ "$SKIP_SMOKE" == "1" ]]; then
   note "SKIP_SMOKE=1, skipping."
   exit 0
 fi
 
-# Install the CLI into the user's site-packages.
-if ! command -v formica >/dev/null; then
-  note "Installing formica CLI (pip install -e)..."
-  python3 -m pip install --user -e ".[dev]"
-  export PATH="$HOME/.local/bin:$PATH"
-fi
-
-# Port-forwards. Kill any old ones first.
-pkill -f "kubectl.*port-forward.*neo4j"  2>/dev/null || true
-pkill -f "kubectl.*port-forward.*vllm"   2>/dev/null || true
-sleep 1
-kubectl -n formica port-forward svc/neo4j 7687:7687 >/tmp/pf-neo4j.log 2>&1 &
-kubectl -n formica port-forward svc/vllm  8080:8080 >/tmp/pf-vllm.log  2>&1 &
-sleep 3
-
-export FORMICA_NEO4J_URI="bolt://localhost:7687"
-export FORMICA_MODEL_BASE_URL="http://localhost:8080/v1"
-
-note "Running: formica solve \"Prove sqrt(2) is irrational\" --budget 1 --timeout 600"
-formica solve "Prove sqrt(2) is irrational" --budget 1 --timeout 600
+note "Running: kubectl exec -n formica deploy/formica-controller -- formica --help"
+kubectl exec -n formica deploy/formica-controller -- formica --help
 
 echo
 echo "==================================================="

--- a/scripts/launch-single-box.sh
+++ b/scripts/launch-single-box.sh
@@ -144,14 +144,28 @@ if ! command -v buildctl >/dev/null; then
 fi
 
 if ! pgrep -x buildkitd >/dev/null; then
-  sudo nohup /usr/local/bin/buildkitd \
+  # Redirect must be inside the sudo'd shell or it runs as the calling user
+  # and fails with Permission denied on /var/log/.
+  sudo sh -c 'nohup /usr/local/bin/buildkitd \
     --oci-worker=false \
     --containerd-worker=true \
     --containerd-worker-addr=/run/k3s/containerd/containerd.sock \
     --containerd-worker-namespace=k8s.io \
-    >/var/log/buildkitd.log 2>&1 &
-  sleep 4
+    >/var/log/buildkitd.log 2>&1 &'
+  # Wait for the socket to appear; bail if buildkitd died.
+  for i in {1..20}; do
+    if [[ -S /run/buildkit/buildkitd.sock ]]; then break; fi
+    sleep 1
+  done
+  if [[ ! -S /run/buildkit/buildkitd.sock ]]; then
+    echo "buildkitd failed to start. Last 40 lines of /var/log/buildkitd.log:"
+    sudo tail -40 /var/log/buildkitd.log || true
+    exit 1
+  fi
 fi
+
+note "Verifying buildkitd worker is reachable..."
+sudo /usr/local/bin/buildctl debug workers >/dev/null
 
 note "Building formica:latest (this pulls the base image on first run)..."
 sudo /usr/local/bin/buildctl build \


### PR DESCRIPTION
## Summary

Follow-up to #12. Bundles four real fixes discovered during repeated single-box launcher runs, and switches the smoke test path from a host-side `pip install -e .` to `kubectl exec` into the controller pod.

### (a) Launcher fixes

- **Fix buildkitd start.** The `nohup ... >/var/log/buildkitd.log 2>&1 &` redirect needs to be inside the `sudo`'d shell or it runs as the calling user and fails with Permission denied on `/var/log/`. Also adds a wait loop for `/run/buildkit/buildkitd.sock` before proceeding.
- **Use `sudo test -S`** to check the buildkit socket, since `/run/buildkit` is mode 0770 root:root and a non-root `test -S` silently returns false.
- **`enableServiceLinks: false`** in `deploy/k8s/base/vllm.yaml`. Kubernetes auto-injects `*_PORT_*` env vars for every Service in the namespace; vLLM's env var parsing picks up `VLLM_PORT` from the vllm Service's own `VLLM_PORT_8080_TCP_PORT=8080` variant and starts listening on the wrong port.
- **Split disk preflight** in `scripts/launch-single-box.sh` into a structural check (root volume >=150 GB total, always enforced, since the vLLM image + build cache + kubelet ephemeral cannot fit otherwise) and an advisory free-space check (>=60 GB free, only relevant on the first run before the vLLM image is pulled).

### (b) Smoke test path change

- `scripts/launch-single-box.sh`: remove the host-side `pip install -e ".[dev]"` + port-forward + `formica solve` block; replace with a final `kubectl exec -n formica deploy/formica-controller -- formica --help` check.
- `docs/launch-on-aws.md`: same substitution for the smoke test, and for the "Running more solves" / "Deploy and solve" examples; new "Neo4j credentials" subsection noting the default `changeme` password from the `neo4j-auth` Secret and how to override via a kustomize patch.
- `README.md`: same substitution in the Launch section.

**Rationale.** Amazon Linux 2023 ships Python 3.9, but `strands-agents-tools>=0.1.0` (a transitive dependency of the formica CLI) requires Python `>=3.10`, so a host-side editable install fails at resolution. Rather than install a second Python toolchain on the host, the canonical single-box smoke test now runs inside the controller pod, which already has Python 3.12, the CLI installed, and in-cluster connectivity to Neo4j and vLLM. This also aligns with the "one machine, k8s-native" principle already in the docs.

### (c) Known gap

This PR gets a `formica solve` command running end-to-end inside the controller pod, but end-to-end solves **do not yet produce validated Evidence.** An Objective and its SubProblems are written to Neo4j, and scout / forager / validator pods are spawned, but 0 Evidence and 0 Validation nodes are created in a 10-minute budget and the Objective stays at `status=NULL`. This is product-layer agent logic, tracked in #13.

Known: end-to-end solve does not yet produce validated Evidence, tracked in #13.

## Test plan

- [ ] Re-run `bash scripts/launch-single-box.sh` on a fresh AL2023 + rome AMI `g5.xlarge` with a 200 GB gp3 root; confirm the launcher reaches the `kubectl exec -- formica --help` step and exits 0.
- [ ] Confirm `kubectl -n formica get pods` shows neo4j-0, formica-controller, otel-collector, and vllm all Running.
- [ ] Sanity-check the new disk preflight on a too-small volume (100 GB): confirm it errors out on the structural check with an explicit message.
- [ ] Verify no em-dashes introduced in docs or code.