### PR TITLE
Failing regression tests for issue #13 (scout/forager)

### DIFF
--- a/tests/unit/test_issue_13_scout_forager.py
+++ b/tests/unit/test_issue_13_scout_forager.py
@@ -1,0 +1,326 @@
+"""Regression tests for issue #13: scout re-decomposes leaves, forager no-ops on valid leaf.
+
+These tests pin down the two symptoms observed on the k3s cluster:
+
+1. Scout decomposes SubProblems that already have children, producing nested
+   "Approach N: Approach N: ..." chains up to 6 levels deep.
+2. Forager always returns `forager.no-op` even when handed a valid leaf
+   SubProblem as its focus, because `read_neighborhood` does not populate
+   `_labels` on the returned node dicts, so `_has_label` is never True.
+
+Both tests are written against an in-memory Forum stub that mimics the
+real `read_neighborhood` contract. No Neo4j, no LLM, no k3s.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from formica.agents.forager import Forager
+from formica.agents.scout import Scout
+from formica.blackboard.forum import Forum
+from formica.config import FormicaConfig
+
+
+@dataclass
+class FakeNode:
+    id: str
+    labels: list[str]
+    props: dict = field(default_factory=dict)
+
+
+@dataclass
+class FakeEdge:
+    id: str
+    type: str
+    start: str
+    end: str
+    pheromones: list = field(default_factory=list)
+
+
+class FakeForum(Forum):
+    """In-memory Forum that mirrors the real contract for read_neighborhood
+    and captures writes (insert_subproblem / insert_evidence) so tests can
+    inspect side effects without Neo4j."""
+
+    def __init__(self):
+        # Skip parent __init__ (no Neo4j driver)
+        self.config = FormicaConfig()
+        self._driver = None
+        self.nodes: dict[str, FakeNode] = {}
+        self.edges: list[FakeEdge] = []
+        self.inserted_subproblems: list = []
+        self.inserted_evidence: list = []
+        self.deposits: list[dict] = []
+
+    # --- test helpers ---
+
+    def add_node(self, node_id: str, labels: list[str], **props) -> None:
+        self.nodes[node_id] = FakeNode(id=node_id, labels=labels, props={"id": node_id, **props})
+
+    def add_edge(self, edge_id: str, type_: str, start: str, end: str) -> None:
+        self.edges.append(FakeEdge(id=edge_id, type=type_, start=start, end=end))
+
+    def is_leaf_subproblem(self, sp_id: str) -> bool:
+        """A SubProblem is a leaf if no other SubProblem has it as parent
+        (no incoming CHILD_OF from another SubProblem)."""
+        for e in self.edges:
+            if e.type == "CHILD_OF" and e.end == sp_id:
+                child = self.nodes.get(e.start)
+                if child and "SubProblem" in child.labels:
+                    return False
+        return True
+
+    # --- Forum contract used by agents ---
+
+    def read_neighborhood(self, focus_id: str, radius: int = 2) -> dict:
+        focus = self.nodes.get(focus_id)
+        if focus is None:
+            return {"focus": None, "neighbors": [], "edges": []}
+
+        # BFS within `radius` hops.
+        visited = {focus_id}
+        frontier = {focus_id}
+        for _ in range(radius):
+            next_frontier = set()
+            for node_id in frontier:
+                for e in self.edges:
+                    for other in (e.start, e.end):
+                        if node_id in (e.start, e.end) and other not in visited:
+                            visited.add(other)
+                            next_frontier.add(other)
+            frontier = next_frontier
+
+        neighbor_ids = visited - {focus_id}
+        neighbors = []
+        for nid in neighbor_ids:
+            n = self.nodes.get(nid)
+            if n is None:
+                continue
+            d = dict(n.props)
+            # Contract: include labels so agents can filter by type.
+            d["_labels"] = list(n.labels)
+            neighbors.append(d)
+
+        edges = [
+            {
+                "id": e.id,
+                "type": e.type,
+                "start": e.start,
+                "end": e.end,
+                "pheromones": list(e.pheromones),
+            }
+            for e in self.edges
+            if e.start in visited and e.end in visited
+        ]
+
+        focus_dict = dict(focus.props)
+        focus_dict["_labels"] = list(focus.labels)
+        return {"focus": focus_dict, "neighbors": neighbors, "edges": edges}
+
+    def insert_subproblem(self, sp) -> str:
+        self.inserted_subproblems.append(sp)
+        eid = f"edge-{len(self.edges)}"
+        self.add_edge(eid, "CHILD_OF", sp.id, sp.parent_id)
+        self.add_node(sp.id, ["SubProblem"], text=sp.text, parent_id=sp.parent_id)
+        return eid
+
+    def insert_evidence(self, ev) -> str:
+        self.inserted_evidence.append(ev)
+        eid = f"edge-{len(self.edges)}"
+        self.add_edge(eid, "SUPPORTS", ev.id, ev.subproblem_id)
+        self.add_node(ev.id, ["Evidence"], content=ev.content)
+        return eid
+
+    def deposit(self, edge_id, channel, amount, half_life_s=None):
+        self.deposits.append(
+            {"edge_id": edge_id, "channel": channel, "amount": amount}
+        )
+
+
+# ---------------------------------------------------------------------------
+# BUG 1: Scout re-decomposes SubProblems that already have children.
+# ---------------------------------------------------------------------------
+
+
+def test_scout_does_not_redecompose_internal_subproblem():
+    """A SubProblem that already has children should not be decomposed again.
+
+    This test reproduces the nesting bug where the scout repeatedly expands
+    already-expanded nodes, producing "Approach 3: Approach 3: ..." chains.
+    """
+    forum = FakeForum()
+    # Graph: Objective -> SubProblem(already decomposed) -> 3 leaf SubProblems
+    forum.add_node("obj-1", ["Objective"], objective="Prove sqrt(2) is irrational")
+    forum.add_node("sp-parent", ["SubProblem"], text="Approach 1: Prove sqrt(2) is irrational", parent_id="obj-1")
+    forum.add_edge("e0", "CHILD_OF", "sp-parent", "obj-1")
+    for i in range(3):
+        sid = f"sp-leaf-{i}"
+        forum.add_node(sid, ["SubProblem"], text=f"Leaf {i}", parent_id="sp-parent")
+        forum.add_edge(f"e{i+1}", "CHILD_OF", sid, "sp-parent")
+
+    assert not forum.is_leaf_subproblem("sp-parent"), "test fixture sanity: parent is internal"
+    assert forum.is_leaf_subproblem("sp-leaf-0"), "test fixture sanity: sp-leaf-0 is a leaf"
+
+    scout = Scout(agent_id="scout-test", caste="scout", forum=forum, focus_id="sp-parent")
+    result = scout.tick()
+
+    assert result.action == "scout.no-op", (
+        f"scout should skip internal SubProblems but returned action={result.action!r}. "
+        f"This means scout created {len(forum.inserted_subproblems)} new children on "
+        f"'sp-parent' despite it already having 3 children."
+    )
+    assert forum.inserted_subproblems == [], (
+        f"scout inserted {len(forum.inserted_subproblems)} subproblems under an "
+        f"already-decomposed parent (issue #13 nesting bug)."
+    )
+
+
+def test_scout_still_decomposes_leaf_subproblem():
+    """Sanity counterpart: scout SHOULD decompose a leaf SubProblem."""
+    forum = FakeForum()
+    forum.add_node("obj-1", ["Objective"], objective="Prove sqrt(2) is irrational")
+    forum.add_node("sp-leaf", ["SubProblem"], text="Show sqrt(2)=a/b leads to contradiction", parent_id="obj-1")
+    forum.add_edge("e0", "CHILD_OF", "sp-leaf", "obj-1")
+
+    scout = Scout(agent_id="scout-test", caste="scout", forum=forum, focus_id="sp-leaf")
+    result = scout.tick()
+
+    assert result.action == "scout.decomposed", (
+        f"scout should decompose leaf subproblems but returned action={result.action!r}"
+    )
+    assert len(forum.inserted_subproblems) >= 2, "scout should create at least 2 children on a leaf"
+
+
+def test_scout_decomposes_objective_with_no_children():
+    """Objectives are always valid decomposition targets (they have no CHILD_OF-from-SubProblem edges)."""
+    forum = FakeForum()
+    forum.add_node("obj-1", ["Objective"], objective="Prove sqrt(2) is irrational")
+
+    scout = Scout(agent_id="scout-test", caste="scout", forum=forum, focus_id="obj-1")
+    result = scout.tick()
+
+    assert result.action == "scout.decomposed"
+    assert len(forum.inserted_subproblems) >= 2
+
+
+# ---------------------------------------------------------------------------
+# BUG 2: Forager returns no-op on a valid leaf SubProblem focus.
+# ---------------------------------------------------------------------------
+
+
+def test_forager_produces_evidence_for_leaf_subproblem_focus():
+    """When the forager is focused directly on a leaf SubProblem, it must
+    produce Evidence. Today it always returns forager.no-op because
+    Forum.read_neighborhood does not populate _labels on the focus node,
+    making `_has_label(focus, 'SubProblem')` always False.
+    """
+    forum = FakeForum()
+    forum.add_node("obj-1", ["Objective"], objective="Prove sqrt(2) is irrational")
+    forum.add_node(
+        "sp-leaf",
+        ["SubProblem"],
+        text="Show sqrt(2)=a/b in lowest terms leads to a,b both even",
+        parent_id="obj-1",
+    )
+    forum.add_edge("e0", "CHILD_OF", "sp-leaf", "obj-1")
+
+    forager = Forager(agent_id="forager-test", caste="forager", forum=forum, focus_id="sp-leaf")
+    result = forager.tick()
+
+    assert result.action == "forager.evidence", (
+        f"forager should produce evidence for a leaf SubProblem focus but returned "
+        f"action={result.action!r} (issue #13 no-op bug)."
+    )
+    assert len(forum.inserted_evidence) == 1, "forager must insert exactly one Evidence node"
+
+
+def test_forager_produces_evidence_when_subproblems_are_neighbors():
+    """When focus is an Objective and SubProblems are neighbors, forager should
+    pick one and produce Evidence."""
+    forum = FakeForum()
+    forum.add_node("obj-1", ["Objective"], objective="Prove sqrt(2) is irrational")
+    for i in range(3):
+        sid = f"sp-{i}"
+        forum.add_node(sid, ["SubProblem"], text=f"approach {i}", parent_id="obj-1")
+        forum.add_edge(f"e{i}", "CHILD_OF", sid, "obj-1")
+
+    forager = Forager(agent_id="forager-test", caste="forager", forum=forum, focus_id="obj-1")
+    result = forager.tick()
+
+    assert result.action == "forager.evidence", (
+        f"forager should produce evidence when SubProblems are in-neighborhood but "
+        f"returned action={result.action!r}."
+    )
+    assert len(forum.inserted_evidence) == 1
+
+
+def test_forager_no_op_when_no_subproblems_anywhere():
+    """Sanity counterpart: legitimately no-op when there are no SubProblems at all."""
+    forum = FakeForum()
+    forum.add_node("obj-1", ["Objective"], objective="Prove sqrt(2) is irrational")
+
+    forager = Forager(agent_id="forager-test", caste="forager", forum=forum, focus_id="obj-1")
+    result = forager.tick()
+
+    assert result.action == "forager.no-op"
+    assert forum.inserted_evidence == []
+
+
+# ---------------------------------------------------------------------------
+# BUG 2b: Forum.read_neighborhood contract - must include _labels.
+#
+# This test pins down the root cause of the forager no-op we saw in production.
+# The current implementation returns dict(node) which only extracts properties,
+# not labels. Every agent that calls _has_label will see False.
+# ---------------------------------------------------------------------------
+
+
+class ForumWithoutLabels(Forum):
+    """Mimics the current production Forum.read_neighborhood behavior: does NOT
+    include _labels in returned node dicts. This is what ships today."""
+
+    def __init__(self):
+        self.config = FormicaConfig()
+        self._driver = None
+        self.inserted_evidence: list = []
+
+    def read_neighborhood(self, focus_id: str, radius: int = 2) -> dict:
+        # Exactly what the real Forum does today (forum.py lines 140-168):
+        # properties only, no labels.
+        if focus_id == "sp-leaf":
+            return {
+                "focus": {"id": "sp-leaf", "text": "leaf problem", "parent_id": "obj-1"},
+                "neighbors": [
+                    {"id": "obj-1", "objective": "top-level goal"},
+                ],
+                "edges": [{"id": "e0", "type": "CHILD_OF", "start": "sp-leaf", "end": "obj-1"}],
+            }
+        return {"focus": None, "neighbors": [], "edges": []}
+
+    def insert_evidence(self, ev) -> str:
+        self.inserted_evidence.append(ev)
+        return "edge-ev-0"
+
+    def deposit(self, *a, **kw):
+        pass
+
+
+def test_forum_contract_labels_missing_reproduces_forager_no_op():
+    """Pins down the production bug: the current Forum.read_neighborhood
+    omits _labels, so the forager cannot recognize a SubProblem and no-ops.
+
+    When this test starts failing (forager.evidence instead of forager.no-op),
+    it means Forum.read_neighborhood has been fixed to include labels and this
+    regression test should be deleted or flipped.
+    """
+    forum = ForumWithoutLabels()
+    forager = Forager(agent_id="forager-test", caste="forager", forum=forum, focus_id="sp-leaf")
+    result = forager.tick()
+
+    # Today this asserts .no-op, confirming the bug.
+    assert result.action == "forager.no-op", (
+        f"Expected no-op given current Forum contract (no _labels), got {result.action!r}. "
+        f"If Forum.read_neighborhood now includes _labels, update this test."
+    )
+    assert forum.inserted_evidence == []


### PR DESCRIPTION
Scaffolding PR so we can drive the issue #13 fix test-first. No production code changes.

## What this adds

`tests/unit/test_issue_13_scout_forager.py` — 7 tests, runs in ~1s with no Neo4j or LLM.

| # | Test | Status today | What it proves |
|---|------|--------------|----------------|
| 1 | `test_scout_does_not_redecompose_internal_subproblem` | **FAIL** | Scout decomposes an already-decomposed SubProblem (3 existing children); this is the 'Approach 3: Approach 3: ...' nesting bug |
| 2 | `test_scout_still_decomposes_leaf_subproblem` | pass | Counterpart; scout must still work on leaves |
| 3 | `test_scout_decomposes_objective_with_no_children` | pass | Objectives remain valid decomposition targets |
| 4 | `test_forager_produces_evidence_for_leaf_subproblem_focus` | pass | Given a Forum contract that includes `_labels`, forager does produce Evidence |
| 5 | `test_forager_produces_evidence_when_subproblems_are_neighbors` | pass | Forager works when SubProblems are in the neighborhood |
| 6 | `test_forager_no_op_when_no_subproblems_anywhere` | pass | Legitimate no-op case |
| 7 | `test_forum_contract_labels_missing_reproduces_forager_no_op` | pass (asserts buggy behavior) | Pins the root cause: `Forum.read_neighborhood` does `dict(node)` which omits labels, so `_has_label` is always False |

## Root causes (narrowed to two small changes)

**Bug A — scout over-decomposition (scout.py + entrypoint._pick_focus).**
Neither the scout's `act()` nor `_pick_focus` for the scout component filters for SubProblems without children. Two possible fixes:
- Filter in Cypher: `MATCH (n) WHERE (n:Objective OR n:SubProblem) AND NOT ()-[:CHILD_OF]->(n) ...`
- Guard in `Scout.act`: refuse to decompose a focus that has incoming CHILD_OF from another SubProblem.

Belt and braces would be both.

**Bug B — forum contract missing labels (forum.py:153-154).**
`read_neighborhood` returns `dict(r["focus"])` / `dict(n)`, which only extracts node properties from the neo4j driver result, not labels. Every agent that calls `_has_label` (currently only forager) silently sees empty labels.

Fix:
```python
focus_d = dict(rec['focus'])
focus_d['_labels'] = list(rec['focus'].labels)
```
and the same for each neighbor.

## How to use this PR

1. Watch test #1 fail locally.
2. Patch `Scout.act` (or `_pick_focus`) → test #1 should flip green.
3. Patch `Forum.read_neighborhood` → test #7 flips from asserting buggy behavior to asserting correct behavior (rewrite it: expected action becomes `forager.evidence`).
4. Rerun the k3s smoke: `kubectl exec -n formica deploy/formica-controller -- formica solve "Prove sqrt(2) is irrational" --budget 1 --timeout 120 --stream` — should produce Evidence and Validation rows in Neo4j.

Tracks #13.