### PR TITLE
Fix issue #13: scout over-decomposition + forager no-op

### DIFF
--- a/formica/agents/entrypoint.py
+++ b/formica/agents/entrypoint.py
@@ -47,17 +47,25 @@ def _agent_for(component: str, forum: Forum, cfg: FormicaConfig) -> Agent:
 def _pick_focus(component: str, forum: Forum) -> str | None:
     """Pick a focus node id for this caste's tick."""
     if component == "scout":
-        # Pick any Objective/SubProblem.
+        # Scouts should only be handed nodes that have no SubProblem children
+        # yet. Otherwise we recursively decompose already-decomposed subtrees
+        # (issue #13). Objectives always qualify; SubProblems qualify only when
+        # no other SubProblem links to them via CHILD_OF.
         with forum._session() as s:  # noqa: SLF001
             rec = s.run(
-                "MATCH (n) WHERE (n:Objective OR n:SubProblem) RETURN n.id AS id "
-                "ORDER BY rand() LIMIT 1"
+                "MATCH (n) WHERE (n:Objective OR n:SubProblem) "
+                "AND NOT (:SubProblem)-[:CHILD_OF]->(n) "
+                "RETURN n.id AS id ORDER BY rand() LIMIT 1"
             ).single()
             return rec["id"] if rec else None
     if component == "forager":
+        # Prefer leaf SubProblems (no SubProblem children). Foragers produce
+        # Evidence on actionable leaves, not on internal decomposition nodes.
         with forum._session() as s:  # noqa: SLF001
             rec = s.run(
-                "MATCH (n:SubProblem) RETURN n.id AS id ORDER BY rand() LIMIT 1"
+                "MATCH (n:SubProblem) "
+                "WHERE NOT (:SubProblem)-[:CHILD_OF]->(n) "
+                "RETURN n.id AS id ORDER BY rand() LIMIT 1"
             ).single()
             return rec["id"] if rec else None
     if component.startswith("validator") or component.startswith("inquiline"):

--- a/formica/agents/scout.py
+++ b/formica/agents/scout.py
@@ -32,6 +32,18 @@ class Scout(Agent):
         if not parent_id or not parent_text:
             return AgentResult(action="scout.no-op", notes="no focus")
 
+        # Guard against recursive over-decomposition (issue #13). A SubProblem
+        # that already has SubProblem children must not be decomposed again,
+        # otherwise scouts produce nested "Approach N: Approach N: ..." chains
+        # and foragers never find real leaves to work on. Objectives are always
+        # valid targets.
+        focus_labels = focus.get("_labels") or []
+        if "SubProblem" in focus_labels and _has_subproblem_child(focus, neighborhood):
+            return AgentResult(
+                action="scout.no-op",
+                notes="focus already decomposed",
+            )
+
         # LLM call is optional - a deterministic fallback lets us run without a model
         # (e.g. unit tests, the toy math e2e).
         subproblem_texts = self._decompose(parent_text)
@@ -74,3 +86,24 @@ class Scout(Agent):
             f"Approach 2 (alternative method): {text}",
             f"Approach 3 (cross-check): {text}",
         ]
+
+
+def _has_subproblem_child(focus: dict, neighborhood: dict) -> bool:
+    """True if `focus` has at least one incoming CHILD_OF edge from a SubProblem.
+
+    CHILD_OF points from child to parent, so an incoming edge (end == focus.id)
+    whose start is a SubProblem means this focus has been decomposed already.
+    """
+    focus_id = focus.get("id")
+    if not focus_id:
+        return False
+    neighbors_by_id = {n.get("id"): n for n in neighborhood.get("neighbors") or []}
+    for e in neighborhood.get("edges") or []:
+        if e.get("type") != "CHILD_OF":
+            continue
+        if e.get("end") != focus_id:
+            continue
+        child = neighbors_by_id.get(e.get("start")) or {}
+        if "SubProblem" in (child.get("_labels") or []):
+            return True
+    return False

--- a/formica/blackboard/forum.py
+++ b/formica/blackboard/forum.py
@@ -150,8 +150,8 @@ class Forum:
             rec = s.run(cypher, focus_id=focus_id).single()
             if rec is None:
                 return {"focus": None, "neighbors": [], "edges": []}
-            focus = dict(rec["focus"]) if rec["focus"] else None
-            neighbors = [dict(n) for n in rec["nbrs"] if n is not None]
+            focus = _node_to_dict(rec["focus"]) if rec["focus"] else None
+            neighbors = [_node_to_dict(n) for n in rec["nbrs"] if n is not None]
             # Flatten paths → distinct edge dicts keyed by elementId
             seen: dict[str, dict] = {}
             for path_rels in rec["rels"] or []:
@@ -256,3 +256,20 @@ class Forum:
 
 def new_id(prefix: str) -> str:
     return f"{prefix}-{uuid.uuid4().hex[:12]}"
+
+
+def _node_to_dict(node) -> dict:
+    """Convert a neo4j Node to a plain dict, preserving labels under `_labels`.
+
+    Agents filter neighborhoods by label (Scout/Forager/Validator all call
+    `_has_label`), so dropping labels on the way out of the DAL silently
+    breaks every caste. Kept as a small helper so the Forum is the single
+    place that knows how to flatten a node.
+    """
+    d = dict(node)
+    try:
+        d["_labels"] = list(node.labels)
+    except AttributeError:
+        # Defensive: plain dict or unexpected type; leave untouched.
+        pass
+    return d

--- a/tests/unit/test_issue_13_scout_forager.py
+++ b/tests/unit/test_issue_13_scout_forager.py
@@ -1,0 +1,326 @@
+"""Regression tests for issue #13: scout re-decomposes leaves, forager no-ops on valid leaf.
+
+These tests pin down the two symptoms observed on the k3s cluster:
+
+1. Scout decomposes SubProblems that already have children, producing nested
+   "Approach N: Approach N: ..." chains up to 6 levels deep.
+2. Forager always returns `forager.no-op` even when handed a valid leaf
+   SubProblem as its focus, because `read_neighborhood` does not populate
+   `_labels` on the returned node dicts, so `_has_label` is never True.
+
+Both tests are written against an in-memory Forum stub that mimics the
+real `read_neighborhood` contract. No Neo4j, no LLM, no k3s.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from formica.agents.forager import Forager
+from formica.agents.scout import Scout
+from formica.blackboard.forum import Forum
+from formica.config import FormicaConfig
+
+
+@dataclass
+class FakeNode:
+    id: str
+    labels: list[str]
+    props: dict = field(default_factory=dict)
+
+
+@dataclass
+class FakeEdge:
+    id: str
+    type: str
+    start: str
+    end: str
+    pheromones: list = field(default_factory=list)
+
+
+class FakeForum(Forum):
+    """In-memory Forum that mirrors the real contract for read_neighborhood
+    and captures writes (insert_subproblem / insert_evidence) so tests can
+    inspect side effects without Neo4j."""
+
+    def __init__(self):
+        # Skip parent __init__ (no Neo4j driver)
+        self.config = FormicaConfig()
+        self._driver = None
+        self.nodes: dict[str, FakeNode] = {}
+        self.edges: list[FakeEdge] = []
+        self.inserted_subproblems: list = []
+        self.inserted_evidence: list = []
+        self.deposits: list[dict] = []
+
+    # --- test helpers ---
+
+    def add_node(self, node_id: str, labels: list[str], **props) -> None:
+        self.nodes[node_id] = FakeNode(id=node_id, labels=labels, props={"id": node_id, **props})
+
+    def add_edge(self, edge_id: str, type_: str, start: str, end: str) -> None:
+        self.edges.append(FakeEdge(id=edge_id, type=type_, start=start, end=end))
+
+    def is_leaf_subproblem(self, sp_id: str) -> bool:
+        """A SubProblem is a leaf if no other SubProblem has it as parent
+        (no incoming CHILD_OF from another SubProblem)."""
+        for e in self.edges:
+            if e.type == "CHILD_OF" and e.end == sp_id:
+                child = self.nodes.get(e.start)
+                if child and "SubProblem" in child.labels:
+                    return False
+        return True
+
+    # --- Forum contract used by agents ---
+
+    def read_neighborhood(self, focus_id: str, radius: int = 2) -> dict:
+        focus = self.nodes.get(focus_id)
+        if focus is None:
+            return {"focus": None, "neighbors": [], "edges": []}
+
+        # BFS within `radius` hops.
+        visited = {focus_id}
+        frontier = {focus_id}
+        for _ in range(radius):
+            next_frontier = set()
+            for node_id in frontier:
+                for e in self.edges:
+                    for other in (e.start, e.end):
+                        if node_id in (e.start, e.end) and other not in visited:
+                            visited.add(other)
+                            next_frontier.add(other)
+            frontier = next_frontier
+
+        neighbor_ids = visited - {focus_id}
+        neighbors = []
+        for nid in neighbor_ids:
+            n = self.nodes.get(nid)
+            if n is None:
+                continue
+            d = dict(n.props)
+            # Contract: include labels so agents can filter by type.
+            d["_labels"] = list(n.labels)
+            neighbors.append(d)
+
+        edges = [
+            {
+                "id": e.id,
+                "type": e.type,
+                "start": e.start,
+                "end": e.end,
+                "pheromones": list(e.pheromones),
+            }
+            for e in self.edges
+            if e.start in visited and e.end in visited
+        ]
+
+        focus_dict = dict(focus.props)
+        focus_dict["_labels"] = list(focus.labels)
+        return {"focus": focus_dict, "neighbors": neighbors, "edges": edges}
+
+    def insert_subproblem(self, sp) -> str:
+        self.inserted_subproblems.append(sp)
+        eid = f"edge-{len(self.edges)}"
+        self.add_edge(eid, "CHILD_OF", sp.id, sp.parent_id)
+        self.add_node(sp.id, ["SubProblem"], text=sp.text, parent_id=sp.parent_id)
+        return eid
+
+    def insert_evidence(self, ev) -> str:
+        self.inserted_evidence.append(ev)
+        eid = f"edge-{len(self.edges)}"
+        self.add_edge(eid, "SUPPORTS", ev.id, ev.subproblem_id)
+        self.add_node(ev.id, ["Evidence"], content=ev.content)
+        return eid
+
+    def deposit(self, edge_id, channel, amount, half_life_s=None):
+        self.deposits.append(
+            {"edge_id": edge_id, "channel": channel, "amount": amount}
+        )
+
+
+# ---------------------------------------------------------------------------
+# BUG 1: Scout re-decomposes SubProblems that already have children.
+# ---------------------------------------------------------------------------
+
+
+def test_scout_does_not_redecompose_internal_subproblem():
+    """A SubProblem that already has children should not be decomposed again.
+
+    This test reproduces the nesting bug where the scout repeatedly expands
+    already-expanded nodes, producing "Approach 3: Approach 3: ..." chains.
+    """
+    forum = FakeForum()
+    # Graph: Objective -> SubProblem(already decomposed) -> 3 leaf SubProblems
+    forum.add_node("obj-1", ["Objective"], objective="Prove sqrt(2) is irrational")
+    forum.add_node("sp-parent", ["SubProblem"], text="Approach 1: Prove sqrt(2) is irrational", parent_id="obj-1")
+    forum.add_edge("e0", "CHILD_OF", "sp-parent", "obj-1")
+    for i in range(3):
+        sid = f"sp-leaf-{i}"
+        forum.add_node(sid, ["SubProblem"], text=f"Leaf {i}", parent_id="sp-parent")
+        forum.add_edge(f"e{i+1}", "CHILD_OF", sid, "sp-parent")
+
+    assert not forum.is_leaf_subproblem("sp-parent"), "test fixture sanity: parent is internal"
+    assert forum.is_leaf_subproblem("sp-leaf-0"), "test fixture sanity: sp-leaf-0 is a leaf"
+
+    scout = Scout(agent_id="scout-test", caste="scout", forum=forum, focus_id="sp-parent")
+    result = scout.tick()
+
+    assert result.action == "scout.no-op", (
+        f"scout should skip internal SubProblems but returned action={result.action!r}. "
+        f"This means scout created {len(forum.inserted_subproblems)} new children on "
+        f"'sp-parent' despite it already having 3 children."
+    )
+    assert forum.inserted_subproblems == [], (
+        f"scout inserted {len(forum.inserted_subproblems)} subproblems under an "
+        f"already-decomposed parent (issue #13 nesting bug)."
+    )
+
+
+def test_scout_still_decomposes_leaf_subproblem():
+    """Sanity counterpart: scout SHOULD decompose a leaf SubProblem."""
+    forum = FakeForum()
+    forum.add_node("obj-1", ["Objective"], objective="Prove sqrt(2) is irrational")
+    forum.add_node("sp-leaf", ["SubProblem"], text="Show sqrt(2)=a/b leads to contradiction", parent_id="obj-1")
+    forum.add_edge("e0", "CHILD_OF", "sp-leaf", "obj-1")
+
+    scout = Scout(agent_id="scout-test", caste="scout", forum=forum, focus_id="sp-leaf")
+    result = scout.tick()
+
+    assert result.action == "scout.decomposed", (
+        f"scout should decompose leaf subproblems but returned action={result.action!r}"
+    )
+    assert len(forum.inserted_subproblems) >= 2, "scout should create at least 2 children on a leaf"
+
+
+def test_scout_decomposes_objective_with_no_children():
+    """Objectives are always valid decomposition targets (they have no CHILD_OF-from-SubProblem edges)."""
+    forum = FakeForum()
+    forum.add_node("obj-1", ["Objective"], objective="Prove sqrt(2) is irrational")
+
+    scout = Scout(agent_id="scout-test", caste="scout", forum=forum, focus_id="obj-1")
+    result = scout.tick()
+
+    assert result.action == "scout.decomposed"
+    assert len(forum.inserted_subproblems) >= 2
+
+
+# ---------------------------------------------------------------------------
+# BUG 2: Forager returns no-op on a valid leaf SubProblem focus.
+# ---------------------------------------------------------------------------
+
+
+def test_forager_produces_evidence_for_leaf_subproblem_focus():
+    """When the forager is focused directly on a leaf SubProblem, it must
+    produce Evidence. Today it always returns forager.no-op because
+    Forum.read_neighborhood does not populate _labels on the focus node,
+    making `_has_label(focus, 'SubProblem')` always False.
+    """
+    forum = FakeForum()
+    forum.add_node("obj-1", ["Objective"], objective="Prove sqrt(2) is irrational")
+    forum.add_node(
+        "sp-leaf",
+        ["SubProblem"],
+        text="Show sqrt(2)=a/b in lowest terms leads to a,b both even",
+        parent_id="obj-1",
+    )
+    forum.add_edge("e0", "CHILD_OF", "sp-leaf", "obj-1")
+
+    forager = Forager(agent_id="forager-test", caste="forager", forum=forum, focus_id="sp-leaf")
+    result = forager.tick()
+
+    assert result.action == "forager.evidence", (
+        f"forager should produce evidence for a leaf SubProblem focus but returned "
+        f"action={result.action!r} (issue #13 no-op bug)."
+    )
+    assert len(forum.inserted_evidence) == 1, "forager must insert exactly one Evidence node"
+
+
+def test_forager_produces_evidence_when_subproblems_are_neighbors():
+    """When focus is an Objective and SubProblems are neighbors, forager should
+    pick one and produce Evidence."""
+    forum = FakeForum()
+    forum.add_node("obj-1", ["Objective"], objective="Prove sqrt(2) is irrational")
+    for i in range(3):
+        sid = f"sp-{i}"
+        forum.add_node(sid, ["SubProblem"], text=f"approach {i}", parent_id="obj-1")
+        forum.add_edge(f"e{i}", "CHILD_OF", sid, "obj-1")
+
+    forager = Forager(agent_id="forager-test", caste="forager", forum=forum, focus_id="obj-1")
+    result = forager.tick()
+
+    assert result.action == "forager.evidence", (
+        f"forager should produce evidence when SubProblems are in-neighborhood but "
+        f"returned action={result.action!r}."
+    )
+    assert len(forum.inserted_evidence) == 1
+
+
+def test_forager_no_op_when_no_subproblems_anywhere():
+    """Sanity counterpart: legitimately no-op when there are no SubProblems at all."""
+    forum = FakeForum()
+    forum.add_node("obj-1", ["Objective"], objective="Prove sqrt(2) is irrational")
+
+    forager = Forager(agent_id="forager-test", caste="forager", forum=forum, focus_id="obj-1")
+    result = forager.tick()
+
+    assert result.action == "forager.no-op"
+    assert forum.inserted_evidence == []
+
+
+# ---------------------------------------------------------------------------
+# BUG 2b: Forum.read_neighborhood contract - must include _labels.
+#
+# This test pins down the root cause of the forager no-op we saw in production.
+# The current implementation returns dict(node) which only extracts properties,
+# not labels. Every agent that calls _has_label will see False.
+# ---------------------------------------------------------------------------
+
+
+class ForumWithoutLabels(Forum):
+    """Mimics the current production Forum.read_neighborhood behavior: does NOT
+    include _labels in returned node dicts. This is what ships today."""
+
+    def __init__(self):
+        self.config = FormicaConfig()
+        self._driver = None
+        self.inserted_evidence: list = []
+
+    def read_neighborhood(self, focus_id: str, radius: int = 2) -> dict:
+        # Exactly what the real Forum does today (forum.py lines 140-168):
+        # properties only, no labels.
+        if focus_id == "sp-leaf":
+            return {
+                "focus": {"id": "sp-leaf", "text": "leaf problem", "parent_id": "obj-1"},
+                "neighbors": [
+                    {"id": "obj-1", "objective": "top-level goal"},
+                ],
+                "edges": [{"id": "e0", "type": "CHILD_OF", "start": "sp-leaf", "end": "obj-1"}],
+            }
+        return {"focus": None, "neighbors": [], "edges": []}
+
+    def insert_evidence(self, ev) -> str:
+        self.inserted_evidence.append(ev)
+        return "edge-ev-0"
+
+    def deposit(self, *a, **kw):
+        pass
+
+
+def test_forum_contract_labels_missing_reproduces_forager_no_op():
+    """Pins down the production bug: the current Forum.read_neighborhood
+    omits _labels, so the forager cannot recognize a SubProblem and no-ops.
+
+    When this test starts failing (forager.evidence instead of forager.no-op),
+    it means Forum.read_neighborhood has been fixed to include labels and this
+    regression test should be deleted or flipped.
+    """
+    forum = ForumWithoutLabels()
+    forager = Forager(agent_id="forager-test", caste="forager", forum=forum, focus_id="sp-leaf")
+    result = forager.tick()
+
+    # Today this asserts .no-op, confirming the bug.
+    assert result.action == "forager.no-op", (
+        f"Expected no-op given current Forum contract (no _labels), got {result.action!r}. "
+        f"If Forum.read_neighborhood now includes _labels, update this test."
+    )
+    assert forum.inserted_evidence == []

--- a/tests/unit/test_issue_13_scout_forager.py
+++ b/tests/unit/test_issue_13_scout_forager.py
@@ -268,59 +268,52 @@ def test_forager_no_op_when_no_subproblems_anywhere():
 
 
 # ---------------------------------------------------------------------------
-# BUG 2b: Forum.read_neighborhood contract - must include _labels.
+# BUG 2b: Forum._node_to_dict contract - labels must round-trip.
 #
-# This test pins down the root cause of the forager no-op we saw in production.
-# The current implementation returns dict(node) which only extracts properties,
-# not labels. Every agent that calls _has_label will see False.
+# The forager no-op in production traced back to Forum.read_neighborhood
+# flattening neo4j nodes with dict(node), which drops labels. Guards the
+# fix by calling the real helper against a fake neo4j Node.
 # ---------------------------------------------------------------------------
 
 
-class ForumWithoutLabels(Forum):
-    """Mimics the current production Forum.read_neighborhood behavior: does NOT
-    include _labels in returned node dicts. This is what ships today."""
+class _FakeNeoNode:
+    """Mimics neo4j.graph.Node for the label/property flattening contract.
 
-    def __init__(self):
-        self.config = FormicaConfig()
-        self._driver = None
-        self.inserted_evidence: list = []
-
-    def read_neighborhood(self, focus_id: str, radius: int = 2) -> dict:
-        # Exactly what the real Forum does today (forum.py lines 140-168):
-        # properties only, no labels.
-        if focus_id == "sp-leaf":
-            return {
-                "focus": {"id": "sp-leaf", "text": "leaf problem", "parent_id": "obj-1"},
-                "neighbors": [
-                    {"id": "obj-1", "objective": "top-level goal"},
-                ],
-                "edges": [{"id": "e0", "type": "CHILD_OF", "start": "sp-leaf", "end": "obj-1"}],
-            }
-        return {"focus": None, "neighbors": [], "edges": []}
-
-    def insert_evidence(self, ev) -> str:
-        self.inserted_evidence.append(ev)
-        return "edge-ev-0"
-
-    def deposit(self, *a, **kw):
-        pass
-
-
-def test_forum_contract_labels_missing_reproduces_forager_no_op():
-    """Pins down the production bug: the current Forum.read_neighborhood
-    omits _labels, so the forager cannot recognize a SubProblem and no-ops.
-
-    When this test starts failing (forager.evidence instead of forager.no-op),
-    it means Forum.read_neighborhood has been fixed to include labels and this
-    regression test should be deleted or flipped.
+    - dict(node) iterates (key, value) pairs (properties only)
+    - node.labels is a frozenset of labels
     """
-    forum = ForumWithoutLabels()
-    forager = Forager(agent_id="forager-test", caste="forager", forum=forum, focus_id="sp-leaf")
-    result = forager.tick()
 
-    # Today this asserts .no-op, confirming the bug.
-    assert result.action == "forager.no-op", (
-        f"Expected no-op given current Forum contract (no _labels), got {result.action!r}. "
-        f"If Forum.read_neighborhood now includes _labels, update this test."
-    )
-    assert forum.inserted_evidence == []
+    def __init__(self, labels: list[str], **props):
+        self._props = dict(props)
+        self.labels = frozenset(labels)
+
+    def keys(self):
+        return self._props.keys()
+
+    def __iter__(self):
+        return iter(self._props)
+
+    def __getitem__(self, key):
+        return self._props[key]
+
+
+def test_node_to_dict_preserves_labels():
+    from formica.blackboard.forum import _node_to_dict
+
+    node = _FakeNeoNode(["SubProblem"], id="sp-1", text="leaf problem", parent_id="obj-1")
+    d = _node_to_dict(node)
+
+    assert d["id"] == "sp-1"
+    assert d["text"] == "leaf problem"
+    assert "_labels" in d, "Forum must surface neo4j labels under _labels"
+    assert "SubProblem" in d["_labels"]
+
+
+def test_node_to_dict_handles_plain_dict_defensively():
+    """Helper should not crash when handed a plain dict (e.g. from a test fake)."""
+    from formica.blackboard.forum import _node_to_dict
+
+    d = _node_to_dict({"id": "x", "foo": "bar"})
+    assert d["id"] == "x"
+    assert d["foo"] == "bar"
+    # No _labels key required; just must not raise.


### PR DESCRIPTION
Closes #13.

Two root causes, two small fixes. Builds on the failing-tests scaffolding from PR #16 (which can be closed unmerged in favor of this PR; the tests from it land here as a single squashed commit).

## Root cause A — Forum dropped labels

`Forum.read_neighborhood` flattened neo4j nodes with `dict(node)`, which only extracts properties. Every agent that calls `_has_label` (`Forager`, `Validator`) therefore saw empty labels and silently no-op'd. **This is why the 10-minute smoke run produced 0 Evidence despite running 174 SubProblems through the graph.**

Existing `test_tick_loop.py::test_forager_writes_evidence_on_a_subproblem` passed because its `FakeForum` stamped `_labels` on inserted nodes — matching the intended contract, not the actual production behavior. Classic contract-drift.

### Fix
- New `_node_to_dict` helper in `forum.py` wraps `dict(node)` and appends `node.labels` as `_labels`.
- `read_neighborhood` routes both focus and neighbors through it.
- Two unit tests (`test_node_to_dict_preserves_labels`, `test_node_to_dict_handles_plain_dict_defensively`) pin down the contract.

## Root cause B — Scout recursively decomposed internal nodes

Neither `Scout.act` nor `entrypoint._pick_focus` filtered SubProblems that already had children. Ticks repeatedly grabbed internal nodes at random and re-decomposed them, producing the 6-level-deep `Approach 3 (cross-check): Approach 3 (cross-check): ...` chains.

### Fix (belt and braces)
- `Scout.act` now no-ops when focus is a SubProblem with an incoming `CHILD_OF` from another SubProblem. Detection is local to the neighborhood dict.
- `_pick_focus` for the scout uses `AND NOT (:SubProblem)-[:CHILD_OF]->(n)` so scouts are never handed internal nodes in the first place.
- `_pick_focus` for the forager now prefers leaf SubProblems too (same filter, different caste).

## Test results

```
tests/unit:        40 passed  (was 33 before, includes 7 new)
tests/integration:  6 passed
time:              ~1 second, no Neo4j, no LLM
```

The previously-failing `test_scout_does_not_redecompose_internal_subproblem` is now green.

## Next validation step

Restart `i-03314039e456d8f74`, rebuild the controller image (or `kubectl rollout` to pick up the new code), and rerun:

```
kubectl exec -n formica deploy/formica-controller -- formica solve \
  "Prove sqrt(2) is irrational" --budget 1 --timeout 120 --stream
```

Expected: Evidence rows in Neo4j, at least one Validation, and a non-null `terminal_reason` on the Objective. If those three land, that's the MVP milestone.