### PR TITLE
Silence neo4j.notifications WARNING flood (issue #14)

### DIFF
--- a/formica/telemetry/logs.py
+++ b/formica/telemetry/logs.py
@@ -56,6 +56,16 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(payload, default=str)
 
 
+# Noisy third-party loggers that should be quieter than the root level.
+# neo4j.notifications emits a WARNING for every Cypher query whose properties
+# or relationship types don't yet exist in the graph. While the colony is
+# bootstrapping (or running with an empty graph) this floods the controller
+# log with a new entry every ~10s per query. See issue #14.
+_QUIET_LOGGERS: dict[str, int] = {
+    "neo4j.notifications": logging.ERROR,
+}
+
+
 def configure_logging(level: int = logging.INFO) -> None:
     """Configure root logger for JSON output. Idempotent."""
     root = logging.getLogger()
@@ -66,6 +76,8 @@ def configure_logging(level: int = logging.INFO) -> None:
     handler.setFormatter(JsonFormatter())
     root.addHandler(handler)
     root.setLevel(level)
+    for name, lvl in _QUIET_LOGGERS.items():
+        logging.getLogger(name).setLevel(lvl)
     setattr(root, "_formica_configured", True)
 
 

--- a/tests/unit/test_logging_config.py
+++ b/tests/unit/test_logging_config.py
@@ -1,0 +1,65 @@
+"""Regression tests for telemetry.logs configuration.
+
+Covers issue #14: neo4j.notifications floods the controller log with WARNING
+entries every time Cypher references a property/relationship-type that doesn't
+exist yet. Unreadable controller logs made debugging the smoke run painful.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from formica.telemetry import logs as logs_mod
+
+
+def _reset_logging_state():
+    """configure_logging is idempotent via a flag on the root logger; reset it
+    so each test gets a clean pass through the configuration code."""
+    root = logging.getLogger()
+    if hasattr(root, "_formica_configured"):
+        delattr(root, "_formica_configured")
+
+
+def test_configure_logging_silences_neo4j_notifications():
+    _reset_logging_state()
+    logs_mod.configure_logging(level=logging.INFO)
+
+    notifications = logging.getLogger("neo4j.notifications")
+    assert notifications.level == logging.ERROR, (
+        f"neo4j.notifications should be pinned to ERROR (issue #14) but was "
+        f"{logging.getLevelName(notifications.level)}."
+    )
+    # WARNING messages must be suppressed.
+    assert not notifications.isEnabledFor(logging.WARNING)
+    # ERROR messages must still get through.
+    assert notifications.isEnabledFor(logging.ERROR)
+
+
+def test_configure_logging_leaves_other_neo4j_loggers_alone():
+    """Only neo4j.notifications is noisy; the parent neo4j logger should still
+    respect the root level so real connection/driver issues are visible."""
+    _reset_logging_state()
+    logs_mod.configure_logging(level=logging.INFO)
+
+    # Parent neo4j logger has no explicit level set, so effective level follows root.
+    parent = logging.getLogger("neo4j")
+    assert parent.level in (logging.NOTSET, logging.INFO), (
+        f"neo4j (parent) should not be independently quieted; got "
+        f"{logging.getLevelName(parent.level)}."
+    )
+    assert parent.isEnabledFor(logging.WARNING), "neo4j driver WARNINGs must still surface"
+
+
+def test_configure_logging_is_idempotent_and_still_pins_quiet_loggers():
+    """Calling configure_logging twice should not undo the quiet-logger pins
+    (and should not double-add handlers)."""
+    _reset_logging_state()
+    logs_mod.configure_logging(level=logging.INFO)
+    handler_count = len(logging.getLogger().handlers)
+
+    # Second call is a no-op via the _formica_configured flag.
+    logs_mod.configure_logging(level=logging.INFO)
+    assert len(logging.getLogger().handlers) == handler_count
+
+    # But notifications must still be silenced.
+    assert logging.getLogger("neo4j.notifications").level == logging.ERROR


### PR DESCRIPTION
Closes #14.

## Problem

The Neo4j Python driver logs a WARNING at `neo4j.notifications` for every Cypher query that references a property or relationship type not yet present in the graph. With a sparse/empty graph (every new objective) this fires on basically every tick and floods the controller log with a new entry every ~10s per query. During the issue #13 debugging session this made the controller log unreadable.

## Fix

One-line-ish change in the single logging chokepoint. `configure_logging` now pins `neo4j.notifications` to ERROR right after installing the root JSON handler:

```python
_QUIET_LOGGERS: dict[str, int] = {"neo4j.notifications": logging.ERROR}
# ...
for name, lvl in _QUIET_LOGGERS.items():
    logging.getLogger(name).setLevel(lvl)
```

The parent `neo4j` logger is intentionally left alone so real driver issues (connection failures, auth errors, etc.) still surface at WARNING. A dict was used so future noisy loggers can be added in one place.

## Tests

`tests/unit/test_logging_config.py` — 3 new tests, all passing:

| Test | What it covers |
|------|----------------|
| `test_configure_logging_silences_neo4j_notifications` | `neo4j.notifications` is pinned to ERROR; WARNING is suppressed, ERROR still gets through |
| `test_configure_logging_leaves_other_neo4j_loggers_alone` | Parent `neo4j` logger is NOT independently quieted so driver WARNINGs still surface |
| `test_configure_logging_is_idempotent_and_still_pins_quiet_loggers` | Calling `configure_logging` twice doesn't double-register handlers or undo the pin |

Full suite: 41 passed in <1s, no Neo4j, no k3s.

## Stacks with #17

Independent of #17 (issue #13 fix), so can merge in any order. Together they should give us both a working solve loop and a readable log to watch it in.