### PR TITLE
Switch default model from Mistral-7B to Qwen2.5-7B-Instruct-AWQ (ADR-0009)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,12 @@ no Docker-in-the-middle, and no in-process mode.
 
 - `curl`, `systemd`, and root access to install k3s.
 - For local GPU inference: an NVIDIA GPU with drivers and
-  `nvidia-container-toolkit` installed, plus Mistral-7B-AWQ weights at
-  `/opt/models/mistral-awq` on the host. (Skip this if you override to
-  Bedrock or OpenAI via `FORMICA_MODEL_PROVIDER`.)
+  `nvidia-container-toolkit` installed. The default model is
+  Qwen/Qwen2.5-7B-Instruct-AWQ; the vLLM pod's initContainer downloads
+  the weights to `/opt/models/qwen-awq` on first start if they are not
+  already there. Pre-stage the directory to skip the ~5GB download.
+  (Skip this whole block if you override to Bedrock via
+  `FORMICA_MODEL_PROVIDER=bedrock`.)
 - For AWS observability: valid AWS credentials in the shell that runs
   `kubectl apply` (IRSA handles pod-level auth once deployed).
 

--- a/deploy/helm/formica/templates/vllm.yaml
+++ b/deploy/helm/formica/templates/vllm.yaml
@@ -18,6 +18,30 @@ spec:
       labels:
         app.kubernetes.io/component: vllm
     spec:
+      # Stage Qwen AWQ weights on first start if not present on the host.
+      # See ADR-0009 for context.
+      initContainers:
+        - name: download-model
+          image: {{ .Values.vllm.image }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              DEST={{ .Values.vllm.modelPath }}
+              if [ -f "$DEST/config.json" ]; then
+                echo "Model weights already present at $DEST, skipping download."
+                exit 0
+              fi
+              mkdir -p "$DEST"
+              echo "Downloading {{ .Values.vllm.servedModelName }} into $DEST..."
+              huggingface-cli download {{ .Values.vllm.servedModelName }} \
+                --local-dir "$DEST" \
+                --local-dir-use-symlinks False
+              echo "Download complete."
+          volumeMounts:
+            - name: models-rw
+              mountPath: /models
       containers:
         - name: vllm
           image: {{ .Values.vllm.image }}
@@ -25,10 +49,16 @@ spec:
           args:
             - "--model={{ .Values.vllm.modelPath }}"
             - "--served-model-name={{ .Values.vllm.servedModelName }}"
-            - "--quantization=awq"
+            - "--quantization={{ .Values.vllm.quantization | default "awq" }}"
             - "--dtype=float16"
             - "--max-model-len={{ .Values.vllm.maxModelLen }}"
             - "--gpu-memory-utilization={{ .Values.vllm.gpuMemoryUtilization }}"
+            {{- if .Values.vllm.enableAutoToolChoice }}
+            - "--enable-auto-tool-choice"
+            {{- end }}
+            {{- if .Values.vllm.toolCallParser }}
+            - "--tool-call-parser={{ .Values.vllm.toolCallParser }}"
+            {{- end }}
             - "--host=0.0.0.0"
             - "--port=8080"
           ports:
@@ -48,6 +78,10 @@ spec:
             failureThreshold: 60
       volumes:
         - name: models
+          hostPath:
+            path: {{ .Values.vllm.hostModelsPath }}
+            type: Directory
+        - name: models-rw
           hostPath:
             path: {{ .Values.vllm.hostModelsPath }}
             type: Directory

--- a/deploy/helm/formica/values.yaml
+++ b/deploy/helm/formica/values.yaml
@@ -36,18 +36,23 @@ neo4j:
   user: "neo4j"
   password: "changeme"
 
-# In-cluster vLLM (open-weight default, per ADR-0007).
+# In-cluster vLLM (open-weight default, per ADR-0007 as amended by ADR-0009).
 # Disable (vllm.enabled=false) when pointing model_base_url at an external
 # provider, e.g. Bedrock in prod. Single-box k3d users leave this on.
 vllm:
   enabled: true
   image: "vllm/vllm-openai:latest"
-  modelPath: "/models/mistral-awq"
-  servedModelName: "TheBloke/Mistral-7B-Instruct-v0.2-AWQ"
+  modelPath: "/models/qwen-awq"
+  servedModelName: "Qwen/Qwen2.5-7B-Instruct-AWQ"
+  quantization: "awq_marlin"
   maxModelLen: 4096
   gpuMemoryUtilization: 0.85
   gpuCount: 1
   hostModelsPath: "/opt/models"
+  # Qwen2.5 supports native tool calling; set to false only if you swap to
+  # a model that does not (e.g. plain Mistral-Instruct). See ADR-0009.
+  enableAutoToolChoice: true
+  toolCallParser: "hermes"
 
 otel:
   endpoint: "http://otel-collector.formica.svc.cluster.local:4317"

--- a/deploy/k8s/base/vllm.yaml
+++ b/deploy/k8s/base/vllm.yaml
@@ -2,10 +2,18 @@
 # vLLM model server. OpenAI-compatible API on :8080.
 #
 # Single-box (bare k3s on the prebaked GPU AMI): weights are bind-mounted from
-# the host at /opt/models/mistral-awq via a hostPath volume. The GPU is exposed
+# the host at /opt/models/qwen-awq via a hostPath volume. The GPU is exposed
 # to the pod via the NVIDIA device plugin daemonset. The pod runs under the
 # `nvidia` RuntimeClass so containerd launches it with nvidia-container-runtime,
 # which injects /dev/nvidia*, libraries, and CUDA driver into the container.
+#
+# The AMI (ami-079c82d610e02e480) originally shipped only Mistral-7B-AWQ at
+# /opt/models/mistral-awq. Per ADR-0009 we switched the default to
+# Qwen/Qwen2.5-7B-Instruct-AWQ (native tool calling + native system role +
+# stronger reasoning). The `download-model` initContainer pulls the Qwen AWQ
+# weights from Hugging Face into /opt/models/qwen-awq on first pod startup if
+# they are not already staged on the host, so the existing AMI keeps working
+# without a rebuild. Pre-seed the directory (e.g. via SSM) to skip the download.
 #
 # Multi-node (EKS): replace the hostPath volume with a PVC backed by a model
 # cache (e.g. EFS or an initContainer that rsyncs from S3). The Service name
@@ -34,17 +42,49 @@ spec:
       # the URI, fails to parse it, and crashes the engine on startup.
       # See https://docs.vllm.ai/en/stable/serving/env_vars.html
       enableServiceLinks: false
+      initContainers:
+        # Stage Qwen2.5-7B-Instruct-AWQ on the host if it is not already there.
+        # The prebaked rome AMI only ships Mistral weights; this makes the
+        # model swap work without rebuilding the AMI. Idempotent: if the
+        # directory already has config.json we skip the download.
+        - name: download-model
+          image: vllm/vllm-openai:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              DEST=/models/qwen-awq
+              if [ -f "$DEST/config.json" ]; then
+                echo "Qwen AWQ weights already present at $DEST, skipping download."
+                exit 0
+              fi
+              mkdir -p "$DEST"
+              echo "Downloading Qwen/Qwen2.5-7B-Instruct-AWQ into $DEST..."
+              # huggingface-cli ships with the vllm-openai image.
+              huggingface-cli download Qwen/Qwen2.5-7B-Instruct-AWQ \
+                --local-dir "$DEST" \
+                --local-dir-use-symlinks False
+              echo "Download complete."
+          volumeMounts:
+            - name: models-rw
+              mountPath: /models
       containers:
         - name: vllm
           image: vllm/vllm-openai:latest
           imagePullPolicy: IfNotPresent
           args:
-            - "--model=/models/mistral-awq"
-            - "--served-model-name=TheBloke/Mistral-7B-Instruct-v0.2-AWQ"
-            - "--quantization=awq"
+            - "--model=/models/qwen-awq"
+            - "--served-model-name=Qwen/Qwen2.5-7B-Instruct-AWQ"
+            - "--quantization=awq_marlin"
             - "--dtype=float16"
             - "--max-model-len=4096"
             - "--gpu-memory-utilization=0.85"
+            # Qwen2.5 exposes native tool calling; vLLM needs both flags
+            # below to accept `tool_choice="auto"` from the forager caste.
+            # See ADR-0009 and issue #24.
+            - "--enable-auto-tool-choice"
+            - "--tool-call-parser=hermes"
             - "--host=0.0.0.0"
             - "--port=8080"
           ports:
@@ -71,7 +111,16 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
       volumes:
+        # Read-only mount for the serving container: vLLM should never mutate
+        # the weights directory.
         - name: models
+          hostPath:
+            path: /opt/models
+            type: Directory
+        # Read-write mount for the initContainer so it can stage weights on
+        # first pod startup. Same hostPath, different volume entry so the
+        # main container can stay read-only.
+        - name: models-rw
           hostPath:
             path: /opt/models
             type: Directory

--- a/docs/decisions/0007-open-weight-default.md
+++ b/docs/decisions/0007-open-weight-default.md
@@ -1,6 +1,9 @@
 # ADR 0007: Default to open-weight Mistral-7B-AWQ served by local vLLM
 
-- Status: Accepted (amended 2026-04-19, see ADR-0008)
+- Status: Accepted (amended 2026-04-19, see ADR-0008; amended
+  2026-04-21, see ADR-0009 which changes the specific model from
+  Mistral-7B-AWQ to Qwen2.5-7B-Instruct-AWQ while keeping the
+  open-weight-first posture)
 - Date: 2026-04-19
 
 ## Context

--- a/docs/decisions/0009-switch-default-to-qwen25.md
+++ b/docs/decisions/0009-switch-default-to-qwen25.md
@@ -1,0 +1,127 @@
+# ADR 0009: Switch default open-weight model from Mistral-7B to Qwen2.5-7B-AWQ
+
+- Status: Accepted (amends ADR-0007)
+- Date: 2026-04-21
+
+## Context
+
+ADR-0007 pinned the default open-weight model to
+`TheBloke/Mistral-7B-Instruct-v0.2-AWQ`, inherited from the rome AMI
+(`ami-079c82d610e02e480`). That default got us to a working end-to-end
+smoke test (PR #23 landed the two LLM wiring fixes: missing `api_key`
+and forced system/user role merging), but the first real run surfaced
+three intrinsic limits of Mistral-7B-Instruct as the Formica model:
+
+1. The Mistral chat template rejects a leading `system` role with
+   HTTP 400 "Conversation roles must alternate user/assistant/...".
+   We already work around this in `formica/tools/llm.py` by folding
+   the system prompt into the first user turn, but losing the
+   separate system role weakens every caste's instruction adherence.
+2. Mistral-7B-Instruct-v0.2 has no native tool-calling support, and
+   vLLM therefore refuses `tool_choice="auto"` with
+   `'"auto" tool choice requires --enable-auto-tool-choice and
+   --tool-call-parser to be set'`. The forager caste, which passes
+   `tools=[...]`, falls back to non-LLM behavior on every tick
+   (tracked in issue #24).
+3. Mistral-7B is a weak math / reasoning model (MATH pass rate around
+   13%). The first smoke run produced 16 validator verdicts, all
+   `needs_expert`, and 0 `validated` evidence. Formica's validator
+   caste is a bottleneck on model quality, not on plumbing.
+
+Separately, the user has an explicit preference to avoid hosted OpenAI
+for this project on business-model grounds, reinforcing the
+open-weight-first posture from ADR-0007.
+
+## Decision
+
+Change the default model to `Qwen/Qwen2.5-7B-Instruct-AWQ` and update
+the vLLM Deployment to expose native tool calling.
+
+Concretely:
+
+- `FormicaConfig.model_id` default becomes
+  `Qwen/Qwen2.5-7B-Instruct-AWQ` (was
+  `TheBloke/Mistral-7B-Instruct-v0.2-AWQ`).
+- `FormicaConfig.model_base_url` is unchanged
+  (`http://vllm.formica.svc.cluster.local:8080/v1`).
+- `FormicaConfig.model_provider` is unchanged (`openai` protocol).
+- The vLLM Deployment in both `deploy/k8s/base/vllm.yaml` and the Helm
+  chart gains:
+  - `--model=/models/qwen-awq` (was `/models/mistral-awq`)
+  - `--served-model-name=Qwen/Qwen2.5-7B-Instruct-AWQ`
+  - `--quantization=awq_marlin` (Qwen documents the marlin kernel as
+    the preferred AWQ backend on Ampere/Ada; falls back to `awq` if
+    unavailable)
+  - `--enable-auto-tool-choice`
+  - `--tool-call-parser=hermes`
+- A `download-model` initContainer is added to the vLLM pod. It checks
+  for `$DEST/config.json` and, if missing, runs
+  `huggingface-cli download Qwen/Qwen2.5-7B-Instruct-AWQ --local-dir
+  /models/qwen-awq --local-dir-use-symlinks False`. This lets the
+  existing rome AMI keep working: the one-time ~5GB pull happens on
+  first pod startup, and subsequent restarts are instant. Pre-staging
+  the directory (e.g. via SSM) skips the download entirely.
+- The `merged_input` workaround in `formica/tools/llm.py` stays as-is.
+  Qwen2.5 supports a native system role, but keeping the merge keeps
+  the wrapper portable across any OpenAI-compatible backend a user
+  might plug in later.
+
+## Rationale
+
+- Native system-role support: Qwen2.5-Instruct's chat template
+  accepts a leading `system` message, removing the root cause of the
+  alternation 400 fix.
+- Native tool calling: Qwen2.5 emits Hermes-style tool calls; vLLM's
+  `hermes` parser decodes them. This directly closes issue #24 and
+  unblocks the forager caste.
+- Reasoning quality: Qwen2.5-7B scores roughly 50%+ on MATH vs
+  ~13% for Mistral-7B-Instruct-v0.2, and substantially higher on
+  GSM8K and MMLU. Validator and scout outputs should improve in
+  kind without changing any agent code.
+- Same VRAM footprint: AWQ-quantized 7B fits comfortably on the A10G
+  in the existing `g5.xlarge` with `--gpu-memory-utilization=0.85`.
+- No vendor lock-in: weights are Apache-2.0-licensed and hosted on
+  Hugging Face; nothing in Formica's runtime depends on Alibaba
+  infrastructure.
+- Aligns with the user's "no OpenAI dependency" posture without
+  reopening the ADR-0007 decision to default to open weights.
+
+## Alternatives considered
+
+- **Stay on Mistral-7B and just add `--enable-auto-tool-choice +
+  --tool-call-parser=mistral`.** Rejected: fixes #24 only. Does not
+  fix the system-role rejection (still need the merge workaround)
+  and leaves the reasoning gap, which is the actual cause of the
+  0-validated-evidence smoke result.
+- **Llama-3.1-8B-Instruct-AWQ.** Competitive on reasoning and also
+  supports tool calling, but its license forbids using outputs to
+  train other models and has extra use restrictions. Qwen2.5's
+  Apache-2.0 is friendlier for a research project that may later
+  fine-tune on Formica traces.
+- **Qwen2.5-14B-AWQ.** Stronger, but ~9GB in AWQ-INT4; combined with
+  KV cache at 4096 context this is borderline on 24GB A10G with
+  other pods on the box. Revisit if we move off g5.xlarge.
+- **Switch to Bedrock / hosted Claude or GPT-4o for validators only.**
+  Contradicts the user's no-OpenAI posture and reintroduces the cost
+  and dependency concerns ADR-0007 was written to avoid. The hosted
+  path remains available via `FORMICA_MODEL_PROVIDER=bedrock` for
+  users who want it.
+
+## Consequences
+
+- Issue #24 is expected to close once a smoke run confirms the forager
+  caste reaches the model cleanly with `tool_choice="auto"`.
+- The rome AMI does not need to be rebuilt; the initContainer handles
+  the one-time Qwen weight stage. Pod cold start on a fresh AMI grows
+  by several minutes the first time (HF download), then returns to
+  the usual 60-120s.
+- The previous Mistral weights at `/opt/models/mistral-awq` remain on
+  the host. They are unused by Formica, but cost nothing and make it
+  trivial to switch back for A/B comparisons via
+  `FORMICA_MODEL_ID=TheBloke/Mistral-7B-Instruct-v0.2-AWQ` and a
+  matching override on the vLLM args.
+- `test_default_model_is_mistral_awq` is replaced by
+  `test_default_model_is_qwen25_awq`.
+- Existing CI still runs without a GPU: unit and integration tests use
+  `FakeForum`, and the e2e toy-math test monkeypatches
+  `Validator._judge`.

--- a/docs/launch-on-aws.md
+++ b/docs/launch-on-aws.md
@@ -3,14 +3,18 @@
 This is the exact recipe that brings up a working Formica cluster on AWS
 from scratch. It uses the prebaked open-weight AMI from the
 [rome](https://github.com/abacus2000/rome) project, which ships with
-CUDA 13, NVIDIA drivers, `nvidia-container-toolkit`, `nerdctl`, and the
-Mistral-7B-Instruct-v0.2-AWQ weights already staged at
-`/opt/models/mistral-awq`.
+CUDA 13, NVIDIA drivers, `nvidia-container-toolkit`, and `nerdctl`.
+The AMI also has older Mistral-7B-Instruct-v0.2-AWQ weights at
+`/opt/models/mistral-awq` that Formica no longer uses by default. Per
+ADR-0009 the current default model is Qwen/Qwen2.5-7B-Instruct-AWQ; the
+vLLM pod's initContainer downloads those weights into
+`/opt/models/qwen-awq` on first start (~5GB, a few minutes on a g5.xlarge).
 
 If you are on a different AMI, first install drivers and
 `nvidia-container-toolkit` per the
-[NVIDIA docs](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
-and stage weights yourself. Everything else below is identical.
+[NVIDIA docs](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
+You do not need to stage weights yourself; the initContainer handles it.
+Everything else below is identical.
 
 ## TL;DR
 

--- a/docs/single-box.md
+++ b/docs/single-box.md
@@ -16,13 +16,19 @@ Any Linux box that has:
    on the PATH (install `nvidia-container-toolkit`). If you do not have a
    GPU, set `FORMICA_MODEL_PROVIDER=bedrock` and skip the GPU bits.
 2. `curl`, `systemd`, and root access to install k3s.
-3. Mistral-7B-AWQ weights at `/opt/models/mistral-awq` on the host. The
-   vLLM pod mounts this via a `hostPath` volume.
+3. Model weights at `/opt/models/qwen-awq` on the host (the default is
+   Qwen/Qwen2.5-7B-Instruct-AWQ per ADR-0009). The vLLM pod's
+   initContainer will download them from Hugging Face on first start if
+   the directory is missing; pre-stage it to skip the ~5GB pull. The
+   pod mounts the directory via a `hostPath` volume.
 
 The canonical environment is a `g5.xlarge` (or `g4dn.xlarge`) launched
 from the prebaked open-weight AMI (`ami-079c82d610e02e480`) shared with
 the [rome](https://github.com/abacus2000/rome) project. That AMI already
-has everything in items 1–3.
+has items 1 and 2 in place. For item 3, the AMI ships older
+Mistral-7B-AWQ weights at `/opt/models/mistral-awq`; on first vLLM pod
+start the initContainer will download Qwen AWQ into `/opt/models/qwen-awq`
+so you do not have to rebuild the AMI.
 
 For a step-by-step EC2 walkthrough, see [launch-on-aws.md](./launch-on-aws.md).
 

--- a/formica/config.py
+++ b/formica/config.py
@@ -20,12 +20,16 @@ class FormicaConfig(BaseSettings):
 
     # LLM model.
     #
-    # Formica defaults to the open-weight model pre-baked into the GPU AMI
-    # (shared with the rome project): Mistral-7B-Instruct-v0.2-AWQ, served
-    # by vLLM on :8080 with an OpenAI-compatible API. Weights live at
-    # /opt/models/mistral-awq on the AMI and are mounted into the vLLM pod
-    # read-only so nothing is downloaded at boot. See docs/single-box.md and
-    # docs/decisions/0007-open-weight-default.md.
+    # Formica defaults to an open-weight model served by in-cluster vLLM on
+    # :8080 (OpenAI-compatible API). Per ADR-0009 the default is
+    # Qwen/Qwen2.5-7B-Instruct-AWQ: native system-role support, native tool
+    # calling (closes issue #24), and much stronger reasoning than the
+    # previous Mistral-7B default. Weights land at /opt/models/qwen-awq on
+    # the host; the vLLM Deployment has an initContainer that downloads them
+    # from Hugging Face on first start if they are not already staged (so
+    # the existing rome AMI keeps working without a rebuild). See
+    # docs/single-box.md, docs/decisions/0007-open-weight-default.md, and
+    # docs/decisions/0009-switch-default-to-qwen25.md.
     #
     # The default base_url targets in-cluster DNS (the `vllm` Service in the
     # `formica` namespace). The CLI, when run from outside the cluster,
@@ -34,7 +38,7 @@ class FormicaConfig(BaseSettings):
     # To switch to another provider (e.g. Bedrock for prod) override with env:
     #   FORMICA_MODEL_PROVIDER=bedrock FORMICA_MODEL_ID=anthropic.claude-3-...
     model_base_url: str = "http://vllm.formica.svc.cluster.local:8080/v1"
-    model_id: str = "TheBloke/Mistral-7B-Instruct-v0.2-AWQ"
+    model_id: str = "Qwen/Qwen2.5-7B-Instruct-AWQ"
     model_provider: str = "openai"  # openai | ollama | bedrock
     # API key for OpenAI-compatible endpoints. Optional for local vLLM (it
     # ignores the value) but required by the underlying `openai.AsyncOpenAI`

--- a/formica/tools/llm.py
+++ b/formica/tools/llm.py
@@ -54,9 +54,10 @@ def run_json(
 
     # Some models (notably Mistral-Instruct) enforce strict user/assistant
     # alternation in their chat template and reject a leading system message
-    # with HTTP 400 "Conversation roles must alternate ...". To stay portable
-    # across such models and real OpenAI alike, we fold the system_prompt into
-    # the first user message instead of passing it as a separate role.
+    # with HTTP 400 "Conversation roles must alternate ...". The current
+    # Qwen2.5 default does support system messages natively, but we keep
+    # folding the prompt into the first user turn so this wrapper stays
+    # portable across any OpenAI-compatible backend the user might plug in.
     merged_input = (
         f"{system_prompt}\n\n{input_text}" if system_prompt else input_text
     )

--- a/tests/unit/test_model_defaults.py
+++ b/tests/unit/test_model_defaults.py
@@ -1,8 +1,9 @@
 """Guardrail: the default FormicaConfig must target the open-weight GPU AMI.
 
-Per ADR-0007, Formica defaults to Mistral-7B-AWQ served by local vLLM on
-port 8080. If these tests fail, either the default was changed on purpose
-(update ADR-0007 and these tests) or by accident (revert).
+Per ADR-0007 (as amended by ADR-0009), Formica defaults to
+Qwen/Qwen2.5-7B-Instruct-AWQ served by local vLLM on port 8080. If these
+tests fail, either the default was changed on purpose (update the ADRs and
+these tests) or by accident (revert).
 """
 
 from __future__ import annotations
@@ -23,9 +24,9 @@ def _clean_env(monkeypatch):
             monkeypatch.delenv(k, raising=False)
 
 
-def test_default_model_is_mistral_awq():
+def test_default_model_is_qwen25_awq():
     cfg = FormicaConfig()
-    assert cfg.model_id == "TheBloke/Mistral-7B-Instruct-v0.2-AWQ"
+    assert cfg.model_id == "Qwen/Qwen2.5-7B-Instruct-AWQ"
 
 
 def test_default_model_base_url_targets_in_cluster_vllm():


### PR DESCRIPTION
Closes #24 once a smoke run confirms the forager caste reaches the model with tool_choice=auto.

## Why

The previous Mistral-7B-Instruct-v0.2 default hit three intrinsic walls in the first real smoke run:

1. Chat template rejects a leading `system` role (400 `'Conversation roles must alternate user/assistant/...'`), forcing the `merged_input` workaround in `formica/tools/llm.py`.
2. No native tool calling. vLLM 400s the forager caste with `'"auto" tool choice requires --enable-auto-tool-choice and --tool-call-parser to be set'` (issue #24).
3. Weak math / reasoning. First smoke run: 16 validator verdicts, all `needs_expert`, 0 `validated` evidence. Validator quality is a bottleneck on the model, not plumbing.

Qwen2.5-7B-Instruct-AWQ fixes all three:

- Native `system` role support in its chat template.
- Native Hermes-style tool calls, decoded by vLLM's `hermes` parser.
- ~50%+ on MATH (vs ~13% for Mistral-7B-Instruct-v0.2), substantially higher GSM8K and MMLU.

Same ~24GB VRAM footprint fits the existing `g5.xlarge` A10G. Apache-2.0 licence. Aligns with the no-OpenAI-dependency posture for this project without reopening ADR-0007.

## Changes

- `formica/config.py`: `model_id` default => `Qwen/Qwen2.5-7B-Instruct-AWQ`.
- `deploy/k8s/base/vllm.yaml` + `deploy/helm/formica/templates/vllm.yaml`:
  - `--model=/models/qwen-awq`
  - `--served-model-name=Qwen/Qwen2.5-7B-Instruct-AWQ`
  - `--quantization=awq_marlin` (preferred kernel on Ampere/Ada)
  - `--enable-auto-tool-choice`
  - `--tool-call-parser=hermes`
  - New `download-model` initContainer: `huggingface-cli download Qwen/Qwen2.5-7B-Instruct-AWQ` into `/opt/models/qwen-awq` on first pod start if the directory is missing. Keeps the existing rome AMI working without a rebuild; subsequent pod restarts are instant. Pre-stage the directory to skip the ~5GB pull.
- Helm `values.yaml`: adds `quantization`, `enableAutoToolChoice`, `toolCallParser` knobs; flips defaults to the Qwen equivalents.
- `tests/unit/test_model_defaults.py`: renamed assertion pins Qwen2.5 as the default.
- `docs/decisions/0009-switch-default-to-qwen25.md` (new) amending ADR-0007. ADR-0007 status line updated to reference 0009.
- `README.md`, `docs/single-box.md`, `docs/launch-on-aws.md`: updated for the new default and initContainer behaviour.
- `formica/tools/llm.py`: the `merged_input` workaround stays (Qwen does not need it, but keeping the merge keeps the wrapper portable across any OpenAI-compatible backend). Comment updated.

## Testing

```
pytest tests/unit
47 passed
```

## Smoke plan after merge

1. Restart EC2 `i-03314039e456d8f74`.
2. Redeploy; the vLLM initContainer will download the Qwen AWQ weights (~5GB, a few minutes on a g5.xlarge).
3. Run `formica solve 'Prove sqrt(2) is irrational'`.
4. Expect: scout + validator + forager all HTTP 200 against vLLM, at least one `validated` evidence verdict, and no tool-choice 400s. Close #24 if so.
